### PR TITLE
Add custom 'identifier_field' for notes

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -20,15 +20,16 @@ collections:
       - {label: "Location", name: "location", widget: "string", required: false}
       - {label: "Body", name: "body", widget: "markdown"}
   - name: "note" # Used in routes, e.g., /admin/collections/blog
+    identifier_field: date
     label: "Note" # Used in the UI
     folder: "posts" # The path to the folder where the documents are stored
     create: true # Allow users to create new documents in this collection
     slug: "{{year}}-{{month}}-{{day}}-{{hour}}-{{minute}}" # Filename template, e.g., YYYY-MM-DD-title.md
     fields: # The fields for each document, usually in front matter
       - {label: "Title", name: "title", widget: "string", required: false}
-      - {label: "Meta description", name: "description", widget: "string"}
+      - {label: "Meta description", name: "description", widget: "string", default: "A short note"}
       - {label: "Note with title", name: "noteWithTitle", widget: "boolean", default: false, required: false}
-      - {label: "Page-specific robots directive", name: "pageSpecificRobotsDirective", widget: "string", required: false}
+      - {label: "Page-specific robots directive", name: "pageSpecificRobotsDirective", widget: "string", default: "noindex, nofollow", required: false}
       - {label: "Publish Date", name: "date", widget: "datetime", default: {{now}}, date_format: "YYYY-MM-DD", time_format: "HH:mm"}
       - {label: "Tags", name: "tags", widget: "list", default: ["note"]}
       - {label: "Location", name: "location", widget: "string", required: false}


### PR DESCRIPTION
…so that it’s not mandatory to add a title for a note.