### PR TITLE
Revert "Adds decap config for cloudinary media library"

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -3,11 +3,6 @@ backend:
   branch: v3
 publish_mode: editorial_workflow
 media_folder: "img/uploads"
-media_library:
-  name: cloudinary
-  config:
-    cloud_name: fuzzylogic
-    api_key: 389853243577723
 collections:
   - name: "blog" # Used in routes, e.g., /admin/collections/blog
     label: "Blog" # Used in the UI


### PR DESCRIPTION
Reverts fuzzylogicxx/fuzzylogic#145

Doing this because I’m gonna try a different workflow that doesn’t involve Cloudinary. It’ll be Phone camera, then a shortcut to covert and resize, then upload into decap media library (hence needing it to work normally rather then have cloudinary’s media library subbed in), then an 11ty Image transform does the rest. 