### PR TITLE
More font and image based performance tweaks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -32,8 +32,8 @@ module.exports = function(eleventyConfig) {
 		// optional, attributes assigned on <img> override these values.
 		defaultAttributes: {
       sizes: "(max-width: 860px) 100vw, 840px",
-      // loading: "lazy",
-		  // decoding: "async",
+      loading: "lazy",
+		  decoding: "async",
 		},
 	});
 

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -84,10 +84,11 @@
 
   // Regular
   @font-face {
-    font-family: "Source Sans Pro-fallback";
+    font-family: Source Sans Pro-fallback;
     size-adjust: 93.75%;
     src: local("Arial");
     font-weight: 400;
+    font-display: swap;
   }
 
   @font-face {
@@ -100,11 +101,12 @@
 
   // Regular Italic
   @font-face {
-    font-family: "Source Sans Pro-fallback";
+    font-family: Source Sans Pro-fallback;
     size-adjust: 93.75%;
     src: local("Arial");
     font-weight: 400;
     font-style: italic;
+    font-display: swap;
   }
 
   @font-face {
@@ -118,10 +120,11 @@
 
   // Bold
   @font-face {
-    font-family: "Source Sans Pro-fallback";
+    font-family: Source Sans Pro-fallback;
     size-adjust: 95%;
     src: local("Arial");
     font-weight: 600;
+    font-display: swap;
   }
 
   @font-face {
@@ -131,7 +134,6 @@
     font-weight: 600;
     font-display: swap;
   }
-
 }
 
 


### PR DESCRIPTION
After reading web page test suggestions, this:
- Adds `font-display` even to the fallback `@font-face` block, to avoid any unwanted browser behaviours. 
- Also adds `loading=lazy` as a default for 11ty image generated images, because I think i) since I always have `width` and `height` set then the browser should reserve space so there shouldn’t be any CLS issue, and ii) I don’t think there should be much risk of LCP issue because this site is so lean that even an lazy-loaded image should still come in early. 

But I can keep my eye on / test the latter. And maybe find a way to generate the image with loading=lazy for use in lists (or use a different smaller image or no image) while using an image that does not have that attribute on the actual article page. 