### PR TITLE
Remove previous DIY drafts workflow and replaces with one using an 11ty preprocessor

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -14,6 +14,19 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(pluginRss);
   eleventyConfig.addPlugin(pluginSyntaxHighlight);
 
+  // Drafts.
+  // See also _data/eleventyDataSchema.js which validates that
+  // `draft` is either undefined or boolean, and raises an error if not.
+  // TODO: add the above schema file once I’ve switched to ES modules.
+	eleventyConfig.addPreprocessor("drafts", "*", (data, content) => {
+		if(data.draft && process.env.ELEVENTY_RUN_MODE === "build") {
+			return false;
+		}
+	});
+
+
+
+
   eleventyConfig.addPlugin(eleventyImageTransformPlugin, {
 		// which file extensions to process
 		extensions: "html",

--- a/posts/posts.11tydata.js
+++ b/posts/posts.11tydata.js
@@ -10,29 +10,5 @@ module.exports = {
   eleventyComputed: {
     postType: (data) => data.tags[1],
     topLevelCategory: (data) => data.tags[2],
-
-    /**
-     * Custom handling for draft posts so they don’t show up unexpectedly.
-     * If a page has `draft: true` in its YAML frontmatter then this snippet
-     * will set its permalink to false and exclude it from collections.
-     *
-     * For dev builds we will always render the page.
-     */
-    permalink: data => {
-      // in dev environments we want to still access a draft post by visiting its URL directly,
-      // but in production the draft post should not be output to a physical file and available to search engines.
-      if (process.env.NODE_ENV === 'production' && data.draft) {
-        return false;
-      }
-
-      return data.permalink;
-    },
-    eleventyExcludeFromCollections: data => {
-      if (data.eleventyExcludeFromCollections || data.draft) {
-        return true;
-      }
-
-      return false;
-    }
   }
 };


### PR DESCRIPTION
I moved to using [an 11ty preprocessor](https://www.11ty.dev/docs/config-preprocessors/) instead.