### PR TITLE
Delete greymatter excerpts functionality and any DIY stuff I had tacked on 

### DIFF
--- a/_data/tokens.json
+++ b/_data/tokens.json
@@ -3,6 +3,7 @@
   "colorLight": "#fff",
   "colorGreyWithHue": "#f0f0f0",
   "colorGrey": "#eee",
+  "colorGreyDark": "#ccc",
   "colorGreyText": "#757575",
   "colorLink": "rgb(14, 131, 123)",
   "colorLinkHover": "rgb(8,78,73);",

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -48,6 +48,7 @@
           --color-light: {{ tokens.colorLight }};
           --color-grey-with-hue: {{ tokens.colorGreyWithHue }};
           --color-grey: {{ tokens.colorGrey }};
+          --color-grey-dark: {{ tokens.colorGreyDark }};
           --color-grey-text: {{ tokens.colorGreyText }};
           --color-link: {{ tokens.colorLink }};
           --color-link-hover: {{ tokens.colorLinkHover }}; /* 40% darker. Less than 30% wasn’t noticeable on hover */

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -19,36 +19,8 @@
       </div>
     </header>
     <div class="l-flow e-content">
-    {% if (post.data.page.excerpt) -%}
-      {%- set excerpt = post.data.page.excerpt -%}{{ excerpt | markdownStringToHTML | safe }}
-      {% if app.environment == "production" and (post.data.mainImage.url or post.data.mainImage.cloudinary_unique_path) %}
-      <figure>
-      {%- if post.data.mainImage.isAnchor %}<a href="{{ post.url | url }}">{%- endif %}
-        {%- if post.data.mainImage.cloudinary_unique_path %}
-          {% respimgV2
-            "" + post.data.mainImage.cloudinary_unique_path + "",
-            "" + post.data.mainImage.alt + "",
-            post.data.mainImage.aspectRatioWidth,
-            post.data.mainImage.aspectRatioHeight
-          %}
-        {%- else -%}
-          {% respimg "" + post.data.mainImage.url + "", "" + post.data.mainImage.alt + "", "(min-width: 1600px) 646px, (min-width: 700px) 612px, 91.58vw", post.data.mainImage.aspectRatioWidth, post.data.mainImage.aspectRatioHeight %}
-        {%- endif %}
-      {%- if post.data.mainImage.isAnchor %}</a>{%- endif %}
-      {%- if post.data.mainImage.figcaption %}<figcaption>{{ post.data.mainImage.figcaption }}</figcaption>{%- endif %}
-      </figure>
-      {% endif %}
-    {%- else -%}
       {{ post.templateContent | markdownStringToHTML | safe }}
-    {%- endif %}
     </div>
-    {% if (post.data.page.excerpt) -%}
-      <footer class="stack">
-        <a rel="bookmark" class="p-name u-url" href="{{ post.url | url }}">
-          Continue reading <span class="u-visually-hidden">“{{ post.data.title }}”</span>
-        </a>
-      </footer>
-    {%- endif %}
     {# <footer class="stack">
       <div class="cluster">
         <ul class="tags">

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -19,8 +19,14 @@
       </div>
     </header>
     <div class="l-flow e-content">
-      {{ post.templateContent | markdownStringToHTML | safe }}
+      {{ post.content | markdownStringToHTML | safe }}
     </div>
+    {# <footer>
+      <a rel="bookmark" class="p-name u-url" href="{{ post.url | url }}">
+        Continue reading <span class="u-visually-hidden">“{{ post.data.title }}”</span>
+      </a>
+    </footer> #}
+
     {# <footer class="stack">
       <div class="cluster">
         <ul class="tags">

--- a/css/index.css
+++ b/css/index.css
@@ -610,7 +610,9 @@
   @layer components {
     /* Lists of articles */
     .h-feed > * + * {
-      margin-top: var(--space-2xl);
+      margin-top: var(--space-xl);
+      padding-top: var(--space-xl);
+      border-top: var(--border-thin) solid var(--color-grey-dark);
     }
 
     /* Individual article */

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -260,11 +260,6 @@ module.exports = function(eleventyConfig) {
     decoding="async" />`;
   });
 
-  // Excerpts (https://www.11ty.io/docs/data-frontmatter/#example%3A-parse-excerpts-from-content)
-  eleventyConfig.setFrontMatterParsingOptions({
-    excerpt: true
-  });
-
 
   //
   // Customize Markdown library and settings:
@@ -283,29 +278,6 @@ module.exports = function(eleventyConfig) {
     // , slugify: eleventyConfig.getFilter("slugify")
   });
   eleventyConfig.setLibrary("md", markdownLibrary);
-
-  // let markdownIt = require('markdown-it');
-  // let markdownItAnchor = require('markdown-it-anchor');
-  // let options = {
-  //   html: true,
-  //   breaks: true,
-  //   linkify: true
-  // };
-  // let opts = {
-  //   permalink: true,
-  //   permalinkClass: 'section-link',
-  //   permalinkSymbol: '#'
-  // };
-
-  // mdi = new markdownIt(options);
-
-  // eleventyConfig.setLibrary('md', mdi.use(markdownItAnchor, opts));
-
-  // Render a markdown string from a .md file (e.g. a post excerpt) as the target HTML in Nunjucks
-
-  eleventyConfig.addNunjucksFilter('markdownStringToHTML', markdownString =>
-    markdownLibrary.render(markdownString)
-  );
 
 
   // Don’t process files of these types; just copy them as-is into the public directory.

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -7,7 +7,6 @@ const { eleventyImageTransformPlugin } = require("@11ty/eleventy-img");
 const { minify } = require("terser");
 
 const markdownIt = require("markdown-it");
-const markdownItAnchor = require("markdown-it-anchor");
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(pluginNavigation);
@@ -268,17 +267,13 @@ module.exports = function(eleventyConfig) {
     html: true,
     breaks: true,
     linkify: true
-  }).use(markdownItAnchor, {
-    permalink: markdownItAnchor.permalink.ariaHidden({
-      placement: "after",
-      class: "direct-link",
-      symbol: "#"
-    }),
-    level: [1,2,3,4]
-    // , slugify: eleventyConfig.getFilter("slugify")
   });
   eleventyConfig.setLibrary("md", markdownLibrary);
 
+  // Render HTML from a markdown string from a .md file (e.g. a post’s content or excerpt)
+  eleventyConfig.addNunjucksFilter('markdownStringToHTML', markdownString =>
+    markdownLibrary.render(markdownString)
+  );
 
   // Don’t process files of these types; just copy them as-is into the public directory.
   // Note: no 'css' entry because we’re inlining CSS so don’t need any physical css files in the public dir.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "encoding": "^0.1.12",
         "luxon": "^1.26.0",
         "markdown-it": "^13.0.1",
-        "markdown-it-anchor": "^8.6.4",
         "npm-run-all": "^4.1.5",
         "slugify": "^1.4.7",
         "terser": "^5.14.2"
@@ -1376,28 +1375,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@types/linkify-it": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-      "peer": true
-    },
-    "node_modules/@types/markdown-it": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.0.1.tgz",
-      "integrity": "sha512-6WfOG3jXR78DW8L5cTYCVVGAsIFZskRHCDo5tbqa+qtKVt4oDRVH7hyIWu1SpDQJlmIoEivNQZ5h+AGAOrgOtQ==",
-      "peer": true,
-      "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
-      }
-    },
-    "node_modules/@types/mdurl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
-      "peer": true
     },
     "node_modules/@ungap/event-target": {
       "version": "0.2.3",
@@ -3459,15 +3436,6 @@
       },
       "bin": {
         "markdown-it": "bin/markdown-it.js"
-      }
-    },
-    "node_modules/markdown-it-anchor": {
-      "version": "8.6.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.4.tgz",
-      "integrity": "sha512-Ul4YVYZNxMJYALpKtu+ZRdrryYt/GlQ5CK+4l1bp/gWXOG2QWElt6AqF3Mih/wfUKdZbNAZVXGR73/n6U/8img==",
-      "peerDependencies": {
-        "@types/markdown-it": "*",
-        "markdown-it": "*"
       }
     },
     "node_modules/markdown-it/node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "encoding": "^0.1.12",
     "luxon": "^1.26.0",
     "markdown-it": "^13.0.1",
-    "markdown-it-anchor": "^8.6.4",
     "npm-run-all": "^4.1.5",
     "slugify": "^1.4.7",
     "terser": "^5.14.2"

--- a/posts/1597093543-inline-javascript-event-handlers-are-resilient.md
+++ b/posts/1597093543-inline-javascript-event-handlers-are-resilient.md
@@ -5,7 +5,6 @@ description: Inline javascript event handlers are useful for avoiding some typic
 tags: [head, javascript, events, performance, resilience, development]
 ---
 I’ve been thinking about [Scott Jehl’s “simplest way to load external CSS asynchronously” technique](https://fuzzylogic.me/posts/2020-08-08-simplest-way-to-load-css-async/). I’m interested in its use of an inline (`onload`) event handler for running JavaScript-based enhancements in the `<head>`, in the context of some broader ruminations on how best to progressively enhance UI elements with JavaScript (for example adding toggle show/hide) without causing layout jank.
----
 
 One really interesting aspect of using inline event handlers to apply enhancements was [highlighted by Chris Ferdinandi today](https://gomakethings.com/progressive-enhancement-graceful-degradation-and-asynchronously-loading-css/): as JavaScript goes, it’s pretty _resilient_.
 

--- a/posts/1984-by-george-orwell.md
+++ b/posts/1984-by-george-orwell.md
@@ -5,7 +5,6 @@ description: I’ve just read George Orwell’s dystopian classic.
 tags: [entry, book, catchup, dystopian]
 ---
 I’ve just read _1984_ by George Orwell. I know, I know… I should have done this a long time ago. Anyway, here’s what I thought.
----
 
 I remember a copy of _1984_ being around the house when I was growing up but for some reason I never got around to reading it. I did, however, see the film when I was young – the “Room 101” scene in particular being unforgettable – and have always known the general plot. 
 

--- a/posts/2018-09-16-cloudinary.md
+++ b/posts/2018-09-16-cloudinary.md
@@ -8,7 +8,6 @@ linkTarget: "https://cloudinary.com/home-6-4-video-b"
 Cloudinary is a very handy tool for image and video upload, storage, optimisation and CDN.
 
 > Store, transform, optimize, and deliver all your media assets with easy-to-use APIs, widgets, or user interface.
----
 
 This was brought to my attention by [Jason Grigsby](https://twitter.com/grigs) at An Event Apart. We were discussing his article series on Responsive Images and I asked if he could recommend a tool which auto-generated all of the images you needed for your responsive image code, if you provide a single source image.
 

--- a/posts/2019-08-01-bookshelf-daverupertcom.md
+++ b/posts/2019-08-01-bookshelf-daverupertcom.md
@@ -6,6 +6,5 @@ tags: [link, books, personalsites]
 linkTarget: "https://daverupert.com/bookshelf/"
 ---
 Just saw this – https://daverupert.com/bookshelf/ – and now I really need to up my book-logging game!
----
 
 (via [@davatron5000](https://twitter.com/davatron5000))

--- a/posts/2019-11-16-you-dont-need-a-media-query-for-that-1-inline-content-separators.md
+++ b/posts/2019-11-16-you-dont-need-a-media-query-for-that-1-inline-content-separators.md
@@ -6,7 +6,6 @@ tags: [link, responsive, css, mediaqueries, flexbox, overflow]
 linkTarget: "https://medium.com/@mandy.michael/you-dont-need-a-media-query-for-that-1-inline-content-separators-a9c562a597a6"
 ---
 > Create a more flexible component which allows the text to wrap based on the content rather than the viewport size.
----
 
 Here, [Mandy Michael](http://batmandy.com/) explores similar territory to [Every Layout](https://every-layout.dev/) in suggesting that not all responsive pattern challenges require, or indeed are best served by, media queries. 
 

--- a/posts/2019-12-04-indieweb-link-sharing-or-max-bock.md
+++ b/posts/2019-12-04-indieweb-link-sharing-or-max-bock.md
@@ -6,7 +6,6 @@ tags: [link, indieweb, github, lambda, netlify, bookmarking]
 linkTarget: "https://mxb.dev/blog/indieweb-link-sharing/"
 ---
 > A pain point of the IndieWeb is that it's sometimes not as convenient to share content as it is on the common social media platforms… That’s why I wanted to improve this process for my site.
----
 
 This was a fantastic walkthrough by [Max](https://twitter.com/mxbck). And based on this, I’ve just finished implementing an easy-bookmarking feature on my own website. 
 

--- a/posts/2019-12-04-who-can-use.md
+++ b/posts/2019-12-04-who-can-use.md
@@ -6,6 +6,5 @@ tags: [link, a11y, colour, vision, contrast]
 linkTarget: "https://whocanuse.com/"
 ---
 > It's a tool that brings attention and understanding to how color contrast can affect different people with visual impairments.
----
 
 What’s interesting about this resource is that sheds light on the many different _types_ of visual impairment, from _Protanomaly_ (trouble distinguishing reds) to _Achromatopsia_ (complete colour blindness; only being able to see shades) and how your website’s colour scheme fares for each. (via paddyduke.com)

--- a/posts/2019-12-10-the-new-dot-com-bubble-is-here-its-called-online-advertising-the-correspondent.md
+++ b/posts/2019-12-10-the-new-dot-com-bubble-is-here-its-called-online-advertising-the-correspondent.md
@@ -6,7 +6,6 @@ tags: [link, advertising, web]
 linkTarget: "https://thecorrespondent.com/100/the-new-dot-com-bubble-is-here-its-called-online-advertising"
 ---
 > Is online advertising working? We simply don’t know
----
 
 This article reveals that despite $273bn being spent on digital ads globally (figures from 2018) the effectiveness of digital advertising is actually borderline impossible to measure. It is highly likely that any favourable figures suggested by marketers owe more to a combination of the “selection effect” and blind faith.
 

--- a/posts/2019-12-11-building-an-accessible-showhide-disclosure-component-with-vanilla-js-go-make-things.md
+++ b/posts/2019-12-11-building-an-accessible-showhide-disclosure-component-with-vanilla-js-go-make-things.md
@@ -6,6 +6,5 @@ tags: [link, a11y, javascript, toggle, disclosure, progressiveenhancement]
 linkTarget: "https://gomakethings.com/building-an-accessible-show/hide-disclosure-component-with-vanilla-js/"
 ---
 > A disclosure component is the formal name for the pattern where you click a button to reveal or hide content. This includes things like a “show more/show less” interaction for some descriptive text below a YouTube video, or a hamburger menu that reveals and hides when you click it.
----
 
 Chris’s article provides an accessible means of showing and hiding content at the press of a button when the native HTML `details` element isn’t suitable.

--- a/posts/2019-12-12-loading-and-templating-json-responses-in-stimulusjs-by-john-beatty.md
+++ b/posts/2019-12-12-loading-and-templating-json-responses-in-stimulusjs-by-john-beatty.md
@@ -6,7 +6,6 @@ tags: [link, stimulus, javascript, api, json]
 linkTarget: "https://johnbeatty.co/2019/01/30/loading-and-templating-json-responses-in-stimulus-js/"
 ---
 Just because Stimulus.js is designed to work primarily with existing HTML doesn’t mean it can’t use JSON APIs when the need arises.
----
 
 Here, John pimps up his Stimulus controller to get and use JSON from a remote API endpoint. 
 

--- a/posts/2019-12-12-multiline-spanning-animated-underline.md
+++ b/posts/2019-12-12-multiline-spanning-animated-underline.md
@@ -6,7 +6,6 @@ tags: [link, animation, css, underline]
 linkTarget: "https://codepen.io/cassie-codes/pen/rNNGdmw"
 ---
 [Cassie Evans](https://twitter.com/cassiecodes) shows us how to combine `background–size`, a `linear-gradient` based `background-image` and a keyframe animation (all in HTML and CSS) for a lovely progressive underline effect on multi-line text.
----
 
 Here’s the gist of it:
 
@@ -19,7 +18,7 @@ body {
   padding: 40vh 30vw;
   font-family: cursive;
   text-align: left;
-  font-size: 130%;  
+  font-size: 130%;
 }
 
 h2 {

--- a/posts/2019-12-14-modest-js-works.md
+++ b/posts/2019-12-14-modest-js-works.md
@@ -8,7 +8,6 @@ linkTarget: "https://modestjs.works/"
 Pascal Laliberté has written a short, free, web-based book which advocates a modest and layered approach to using JavaScript.
 
 > I make the case for The JS Gradient, a principle whereby your app can have multiple coexisting modern JS approaches, starting from the global sprinkles to spot view-models to, yes, an SPA if that’s really necessary. At each point in the gradient, you’ll see when it’s a good idea to go a step further toward heavier JavaScript, or not.
----
 
 Pascal’s philosophy starts with the following ideals:
 

--- a/posts/2019-12-21-carbon.md
+++ b/posts/2019-12-21-carbon.md
@@ -6,7 +6,6 @@ tags: [link, code, tool]
 linkTarget: "https://carbon.now.sh/"
 ---
 > Create and share beautiful images of your source code. Start typing or drop a file into the text area to get started.
----
 
 I’ve noticed [Andy Bell](https://hankchizljaw.com/) using a really lovely format when sharing code snippets on Twitter. Turns out that it was using this great tool.
 

--- a/posts/2019-12-21-making-a-better-custom-select-element-24-ways.md
+++ b/posts/2019-12-21-making-a-better-custom-select-element-24-ways.md
@@ -6,7 +6,6 @@ tags: [link, select, datalist, a11y]
 linkTarget: "https://24ways.org/2019/making-a-better-custom-select-element/"
 ---
 >  We want a way for someone to choose an item from a list of options, but it’s more complicated than just that. We want autocomplete options. We want to put images in there, not just text. The `optgroup` element is ugly, hard to style, and not announced by screen readers. I had high hopes for the `datalist` element, but it’s no good for people with low vision who zoom or use high contrast themes. `select` inputs are limited in a lot of ways. Let’s work out how to make our own while keeping all the accessibility features of the original.
----
 
 Julie Grundy argues here that despite us having [greater ability to style the standard `select`](https://fuzzylogic.me/posts/2019-12-21-styling-a-select-like-its-2019-or-filament-group-inc/) in 2019 there are times when that element doesn’t quite meet modern expectations.
 

--- a/posts/2019-12-21-styling-a-select-like-its-2019-or-filament-group-inc.md
+++ b/posts/2019-12-21-styling-a-select-like-its-2019-or-filament-group-inc.md
@@ -6,7 +6,6 @@ tags: [link, select, forms, html, css]
 linkTarget: "https://www.filamentgroup.com/lab/select-css.html"
 ---
 > Recently, we’d seen some articles suggest that things haven’t changed a great deal with select's styling limitations, but I decided to return to the problem and tinker with it myself to be sure. As it turns out, a reasonable set of styles can create a consistent and attractive select across new browsers, while remaining just fine in older ones too.
----
 
 Here’s a breakthrough in the always-frustrating field of styling form elements. Scott Jehl of Filament Group introduces a new technique for styling the `select` element in a modern way without the need for a parent element, pseudo-elements, or javascript. Thanks, Scott!
 

--- a/posts/2019-12-21-when-should-you-add-the-defer-attribute-to-the-script-element-on-go-make-things.md
+++ b/posts/2019-12-21-when-should-you-add-the-defer-attribute-to-the-script-element-on-go-make-things.md
@@ -8,7 +8,6 @@ linkTarget: "https://gomakethings.com/when-should-you-add-the-defer-attribute-to
 For many years I’ve placed script elements just before the closing `body` tag rather than in the `<head>`. Since a standard `<script>` element is render-blocking, the theory is that by putting it at the end of the document – after the main content of the page has loaded – it’s no longer blocking anything, and there’s no need to wrap it in a `DOMContentLoaded` event listener.
 
 It turns out that my time-honoured default is OK, but there is a better approach.
----
 
 [Chris](https://gomakethings.com/) has done the research for us and ascertained that placing the `<script>` in the `<head>` and adding the `defer` attribute has the same effect as putting that `<script>` just before the closing body tag but offers improved performance. 
 

--- a/posts/2019-12-26-8-days-to-the-moon-and-back-on-bbc-iplayer.md
+++ b/posts/2019-12-26-8-days-to-the-moon-and-back-on-bbc-iplayer.md
@@ -8,6 +8,5 @@ linkTarget: "https://www.bbc.co.uk/iplayer/episode/m0006p5f/8-days-to-the-moon-a
 > Previously classified cockpit audio, recorded by the astronauts themselves, gives a unique insight into their fears and excitement as they undertake the mission. And dramatic reconstruction brings those recordings to life, recreating the crucial scenes that were never filmed - the exhilarating launch, the first sight of the moon, the dramatic touchdown and nail-biting journey home.
 
 Original archive footage from the Apollo programme is combined with newly shot film and cinematic CGI to create the ultimate documentary of the ultimate human adventure.
----
 
 This can only be described as a stunning audiovisual experience and a fantastic tribute on the 50-year anniversary of the Apollo 11 mission!

--- a/posts/2019-12-26-bbc-four-blue-note-records-beyond-the-notes.md
+++ b/posts/2019-12-26-bbc-four-blue-note-records-beyond-the-notes.md
@@ -6,7 +6,6 @@ tags: [link, music, jazz]
 linkTarget: "https://www.bbc.co.uk/programmes/m000b8pd"
 ---
 > The story behind Blue Note Records, founded in New York in 1939 by two German Jewish refugees who allowed their musicians complete artistic freedom, revolutionising jazz in the process.
----
 
 A great watch with a fantastic back story, great interviews and amazing music including this from Art Blakey:
 

--- a/posts/2019-12-26-responsive-type-and-zoom-by-adrian-roselli.md
+++ b/posts/2019-12-26-responsive-type-and-zoom-by-adrian-roselli.md
@@ -6,7 +6,6 @@ tags: [link, a11y, typography, responsive, zoom, viewport]
 linkTarget: "https://adrianroselli.com/2019/12/responsive-type-and-zoom.html"
 ---
 > When people zoom a page, it is typically because they want the text to be bigger. When we anchor the text to the viewport size, even with a (fractional) multiplier, we can take away their ability to do that. It can be as much a barrier as disabling zoom. If a user cannot get the text to 200% of the original size, you may also be looking at a WCAG 1.4.4 Resize text (AA) problem.
----
 
 I already tend to avoid dynamic, viewport-width-based [fluid typography](https://css-tricks.com/snippets/css/fluid-typography/) techniques in favour of making just one font-size adjustment – at a _desktop_ breakpoint – based on the typographic theory that suggests we adjust type size according to _reading distance_. I learned this in Richard Rutter’s excellent book [Web Typography](http://book.webtypography.net/).
 

--- a/posts/2019-12-27-lazy-load-embedded-youtube-videos-csstricks.md
+++ b/posts/2019-12-27-lazy-load-embedded-youtube-videos-csstricks.md
@@ -6,7 +6,6 @@ tags: [link, performance, youtube, video, embed, srcdoc]
 linkTarget: "https://css-tricks.com/lazy-load-embedded-youtube-videos/"
 ---
 > This is a very clever idea via Arthur Corenzan. Rather than use the default YouTube embed, which adds a crapload of resources to a page whether the user plays the video or not, use the little tiny placeholder webpage that is just an image you can click that is linked to the YouTube embed.
----
 
 Here’s a performance-enhancing trick for embedding youtube videos which eschews the default YouTube `embed` (and all the resources it adds to a page whether the video plays or not) in favour of rendering a tiny placeholder webpage in the `srcdoc` attribute. 
 

--- a/posts/2020-01-02-awesome-stock-resources.md
+++ b/posts/2020-01-02-awesome-stock-resources.md
@@ -6,7 +6,6 @@ tags: [link, stock, photography, tile, background, video, illustration, svg, css
 linkTarget: "https://github.com/neutraltone/awesome-stock-resources"
 ---
 > A collection of links for free stock photography, video and illustration websites
----
 
 In case I need more stock photography than I currently get from [Unsplash](https://source.unsplash.com/), this Github-hosted list could be useful. 
 

--- a/posts/2020-01-14-not-every-design-pattern-in-a-design-system-should-be-represented-by-a-component.md
+++ b/posts/2020-01-14-not-every-design-pattern-in-a-design-system-should-be-represented-by-a-component.md
@@ -6,7 +6,6 @@ tags: [link, designsystems, component, pattern]
 linkTarget: "https://css-tricks.com/newsletter/181/"
 ---
 > My point with all this is that it’s easy to see every problem or design as a new component or a mix of currently existing components. But instead, we should make components that can slot into each other neatly, rather just continue to make more components.
----
 
 An interesting observation from Robin Rendle who leads Gousto’s design system.
 

--- a/posts/2020-01-17-bbc-four-primal-scream-the-lost-memphis-tapes.md
+++ b/posts/2020-01-17-bbc-four-primal-scream-the-lost-memphis-tapes.md
@@ -6,7 +6,6 @@ tags: [link, music, rock, vinyl, pressing, recording, glasgow]
 linkTarget: "https://www.bbc.co.uk/programmes/b0brzps8"
 ---
 > The sessions recorded by the band in Memphis with the legendary record producer Tom Dowd, along with the Muscle Shoals Rhythm Section musicians Roger Hawkins, drums, and David Hood, bass, did not make the light of day, because some of the mixes were not suitable in the musical climate at the time.
----
 
 A great watch telling an unlikely, touching and at times hilarious story of how the Glasgow band temporarily escaped the madness of the early 90’s scene for Memphis to record an album which was out of step with the time and only revealed its true quality with the benefit of hindsight and maturity. 
 

--- a/posts/2020-01-29-regexr-learn-build-and-test-regex.md
+++ b/posts/2020-01-29-regexr-learn-build-and-test-regex.md
@@ -6,7 +6,6 @@ tags: [link, regex, development, tool]
 linkTarget: "https://regexr.com/"
 ---
 > RegExr is an online tool to learn, build, & test Regular Expressions.
----
 
 This handy, interactive tool is a bit like [Postman](https://www.getpostman.com/) but for RegEx. You can create RegEx patterns and save them for easy retrieval later. 
 

--- a/posts/2020-02-02-lets-learn-eleventy-with-zach-leatherman-learn-with-jason-youtube.md
+++ b/posts/2020-02-02-lets-learn-eleventy-with-zach-leatherman-learn-with-jason-youtube.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.youtube.com/watch?v=j8mJrhhdHWc"
 <div class="l-frame">
   <iframe title="Let’s Learn Eleventy with Jason Lengstorf" loading="lazy" width="560" height="315" src="https://www.youtube.com/embed/j8mJrhhdHWc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
----
 
 A great tutorial video on Eleventy by Jason Lengstorf with guest Zach Leatherman, creator of Eleventy.
 

--- a/posts/2020-02-06-a-new-technique-for-making-responsive-javascriptfree-charts-dev-community.md
+++ b/posts/2020-02-06-a-new-technique-for-making-responsive-javascriptfree-charts-dev-community.md
@@ -6,6 +6,5 @@ tags: [link, svg, html, css, javascript, graphs, datavis, nodejs]
 linkTarget: "https://dev.to/richharris/a-new-technique-for-making-responsive-javascript-free-charts-gmp"
 ---
 > I wanted to see if it was possible to create SVG charts that would work without JS. Well, it is. I've also created an experimental Svelte component library called Pancake to make these techniques easier to use.
----
 
 A lovely modern, progressively-enhanced approach to data visualisation that uses primarily SVG, HTML and CSS but can be enhanced with JavaScript for Node-based generation or client-side interactivity, if required. (via [@jamesmockett](https://twitter.com/jamesmockett))

--- a/posts/2020-02-10-old-css-new-css-eevee.md
+++ b/posts/2020-02-10-old-css-new-css-eevee.md
@@ -6,6 +6,5 @@ tags: [link, css, hacks, firefox, flexbox, cssgrid]
 linkTarget: "https://eev.ee/blog/2020/02/01/old-css-new-css/"
 ---
 > I first got into web design/development in the late 90s, and only as I type this sentence do I realize how long ago that was. Here’s a history of CSS and web design, as I remember it.
----
 
 A fantastic and amusing account of how we progressed from no CSS (the early days of font tags, inline styles and tables for layout), through bad browsers, untold hacks and browser prefixes, to the relative luxury of today’s tools such as Flexbox and CSS Grid.

--- a/posts/2020-02-16-adactio-journalhydration.md
+++ b/posts/2020-02-16-adactio-journalhydration.md
@@ -6,14 +6,13 @@ tags: [link, progressiveenhancement, javascript, react, hydration, gatsby]
 linkTarget: "https://adactio.com/journal/16404"
 ---
 > The situation we have now is the worst of both worlds: server-side rendering followed by a tsunami of hydration. It has a whiff of progressive enhancement to it (because there’s a cosmetic separation of concerns) but it has none of the user benefits.
----
 
 Jeremy Keith notes that these days JavaScript frameworks like React can be used in different ways: not solely for creating an SPA or for complex client-site state management, but perhaps for JavaScript that is run on the server. A developer might choose React because they like the way it encourages modularity and componentisation. This could be a good thing if frameworks like Gatsby and <span class="nobreak">Next.js</span> were to use progressive enhancement properly.
 
 In reality, the system of _server-side rendering_ of non-interactive HTML that is reliant on a further payload of JavaScript for _hydration_ leads to an initial loading experience that is “jagged and frustrating”.
 
-Jeremy argues that this represents a worst-of-both-worlds situation and that its alleged “progressive enhancement via improved separation of concerns” is missing the point. 
+Jeremy argues that this represents a worst-of-both-worlds situation and that its alleged “progressive enhancement via improved separation of concerns” is missing the point.
 
-> Hope is on the horizon for React in the form of partial hydration. I sincerely hope that it will become the default way of balancing server-side rendering with just-in-time client-side interaction. 
+> Hope is on the horizon for React in the form of partial hydration. I sincerely hope that it will become the default way of balancing server-side rendering with just-in-time client-side interaction.
 
 (via [@adactio](https://twitter.com/adactio))

--- a/posts/2020-02-23-bobby-gillespie-remembers-andrew-weatherall-he-was-a-true-bohemian-the-guardian.md
+++ b/posts/2020-02-23-bobby-gillespie-remembers-andrew-weatherall-he-was-a-true-bohemian-the-guardian.md
@@ -6,7 +6,6 @@ tags: [link, music, primalscream, dj]
 linkTarget: "https://www.theguardian.com/music/2020/feb/23/bobby-gillespie-on-screamadelica-producer-andrew-weatherall?fbclid=IwAR35FdtbJmzOcb_Fzh19jacBBcMANJU_z7fLOEy9biF8tWoe9MLIAiyUoGo"
 ---
 > I think of him as a true bohemian; he made etchings, he wrote, he read a lot. Andrew always had a book on the go, maybe two. I remember he gave me his copy of Hunger by Knut Hamsun when I told him I hadn’t read it. There was this other side to him that was deep, curious, well-read. I guess he was a classic autodidact, hungry for knowledge.
----
 
 Over the last week, the UK music scene has been remembering Andrew Weatherall who sadly died aged only 56.
 

--- a/posts/2020-02-23-you-dont-need.md
+++ b/posts/2020-02-23-you-dont-need.md
@@ -6,7 +6,6 @@ tags: [link, javascript, lean, tool, development, css, momentjs, lodash]
 linkTarget: "https://github.com/you-dont-need"
 ---
 A nice list of tips and tools on how to use simpler browser standards and APIs to avoid the added weight of unnecessary JavaScript and libraries.
----
 
 Lodash, Moment and other similar libraries are _expensive_ and we don’t always need them. This Github repo contains a host of nice tips, snippets and code–analysing tools.
 

--- a/posts/2020-02-24-bbc-gel-inclusive-components-technical-guide.md
+++ b/posts/2020-02-24-bbc-gel-inclusive-components-technical-guide.md
@@ -6,6 +6,5 @@ tags: [link, a11y, bbc, inclusive, guide, html, css, javascript]
 linkTarget: "https://bbc.github.io/gel/"
 ---
 > The BBC Global Experience Language (GEL) Technical Guides are a series of framework-agnostic, code-centric recommendations and examples for building GEL design patterns in websites. They illustrate how to create websites that comply with all BBC guidelines and industry best practice, giving special emphasis to accessibility.
----
 
 Heydon Pickering (author of _Inclusive Components_ and co-creator of _Every Layout_) has implemented and documented over 25 of the BBC's design patterns. These are sure to be loaded with best practices and clever tricks for making resilient, accessible modern UI components. (via [@heydonworks](https://twitter.com/heydonworks))

--- a/posts/2020-02-27-the-contrast-triangle.md
+++ b/posts/2020-02-27-the-contrast-triangle.md
@@ -6,7 +6,6 @@ tags: [link, css, a11y, contrast, underline, links]
 linkTarget: "https://contrast-triangle.com/"
 ---
 > Removing underlines from links in HTML text presents an accessibility challenge. In order for a design to be considered accessible, there is now a three-sided design contraint - or what I call "The Contrast Triangle". Your text, links and background colors must now all have sufficient contrast from each other. Links must have a contrast ratio of 3:1 from their surrounding text. By not using underlines, a design has to rely on contrast alone to achieve this.
----
 
 It’s interesting that Chip says that this level of contrast is needed “when we don’t use underlines on links”.
 

--- a/posts/2020-02-28-are-my-colours-accessible.md
+++ b/posts/2020-02-28-are-my-colours-accessible.md
@@ -6,7 +6,6 @@ tags: [link, a11y, contrast, text, colour, tool]
 linkTarget: "https://www.aremycolorsaccessible.com/"
 ---
 > Colour contrast and the use of colour is extremely important for certain groups of people with varying levels of visional impairment. Building upon the excellent Colorable, I wanted more context around the result. When you share the outcome with your colleagues, all the results, rules and what you’re aiming for, is easily understandable for when you have those awkward conversations with designers and marketers. Accessibility doesn’t have to be ugly.
----
 
 An excellent, easy to use tool for checking text-against-background contrast for accessibility and sharing your results with others.
 

--- a/posts/2020-02-28-why-the-govuk-design-system-team-changed-the-input-type-for-numbers-technology-in-government.md
+++ b/posts/2020-02-28-why-the-govuk-design-system-team-changed-the-input-type-for-numbers-technology-in-government.md
@@ -6,7 +6,6 @@ tags: [link, a11y, forms]
 linkTarget: "https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/"
 ---
 > Using `<input type="text" inputmode="numeric" pattern="[0-9]*">` (instead of `<input type="number"`) allows for a degree of separation between how the user enters data (“input mode”), what the browser expects the user input to contain (type equals number), and potentially how it tries to validate it.
----
 
 An interesting post from the UK Government listing a host of usability and accessibility problems arising from using `<input type="number">`. 
 

--- a/posts/2020-03-03-html-the-inaccessible-parts-daverupertcom.md
+++ b/posts/2020-03-03-html-the-inaccessible-parts-daverupertcom.md
@@ -8,6 +8,5 @@ linkTarget: "https://daverupert.com/2020/02/html-the-inaccessible-parts/"
 Here’s Dave Rupert, frustratedly rounding up the accessibility shortfalls in browser implementations of native HTML elements.
 
 >  I’ve always abided in the idea that “HTML is accessible by default and then we come along and mess it up”. But that’s not always the case. There are some cases where even using plain ol’ HTML causes accessibility problems.
----
 
 (via [@jamesmockett](https://twitter.com/jamesmockett))

--- a/posts/2020-03-24-screen-work-together-like-youre-in-the-same-room.md
+++ b/posts/2020-03-24-screen-work-together-like-youre-in-the-same-room.md
@@ -6,7 +6,6 @@ tags: [link, tool, remote, pair, development, collaboration]
 linkTarget: "https://screen.so/"
 ---
 > Fast screen sharing with multiplayer control, drawing & video.
----
 
 An application which allows collaborating (and drawing) on files and could be useful for pair programming. Free during the current COVID-19 situation. 
 

--- a/posts/2020-03-30-4-ways-to-animate-the-color-of-a-text-link-on-hover-or-csstricks.md
+++ b/posts/2020-03-30-4-ways-to-animate-the-color-of-a-text-link-on-hover-or-csstricks.md
@@ -6,7 +6,6 @@ tags: [link, development, link, hover, animation, interactivity, css, transform]
 linkTarget: "https://css-tricks.com/4-ways-to-animate-the-color-of-a-text-link-on-hover/"
 ---
 > Let’s create a pure CSS effect that changes the color of a text link on hover – but slide that new color in instead of simply swapping colors. 
----
 
 Katherines post explores four different techniques to achieve the effect, and their comparative pros and cons with regard to accessibility, performance, and browser support.
 

--- a/posts/2020-03-30-html-attributes-to-improve-your-users-two-factor-authentication-experience-twilio.md
+++ b/posts/2020-03-30-html-attributes-to-improve-your-users-two-factor-authentication-experience-twilio.md
@@ -6,6 +6,5 @@ tags: [link, development, input, forms, html, ux]
 linkTarget: "https://www.twilio.com/blog/html-attributes-two-factor-authentication-autocomplete"
 ---
 > In this post we have seen that with just a sprinkling of HTML attributes we can improve the login experience for our users, particularly on mobile devices.
----
 
 By adding certain attributes to the HTML `input` element – such as `inputmode`, `pattern` and `autocomplete="current-password"` – we can improve the user experience when logging in.

--- a/posts/2020-04-01-emergency-website-kit-max-bock.md
+++ b/posts/2020-04-01-emergency-website-kit-max-bock.md
@@ -6,6 +6,5 @@ tags: [link, 11ty, html, netlify, static, jamstack, coronavirus, performance, cm
 linkTarget: "https://mxb.dev/blog/emergency-website-kit/"
 ---
 > In cases of emergency, many organizations need a quick way to publish critical information. But existing (CMS) websites are often unable to handle sudden spikes in traffic.
----
 
 Fantastic effort by Max Böck here, stepping up during the COVID-19 pandemic to provide this Eleventy template for organisations to use to publish critical information as lean, resilient, static HTML pages.

--- a/posts/2020-04-01-how-to-create-an-accordion-hover-effect-with-boxshadows-sarah-l-fossheim.md
+++ b/posts/2020-04-01-how-to-create-an-accordion-hover-effect-with-boxshadows-sarah-l-fossheim.md
@@ -6,6 +6,5 @@ tags: [link, css, development, animation, boxshadow, card]
 linkTarget: "https://fossheim.io/writing/posts/css-box-shadow-animation/"
 ---
 > In this tutorial we'll use the box-shadow property to create a layered card component, and animate it on hover.
----
 
 Beautiful effects expertly combining colour, clever box-shadow configurations and position-based animation.

--- a/posts/2020-04-07-bem-naming-cheat-sheet-by-9elements.md
+++ b/posts/2020-04-07-bem-naming-cheat-sheet-by-9elements.md
@@ -6,7 +6,6 @@ tags: [link, bem, naming, html, css]
 linkTarget: "https://9elements.com/bem-cheat-sheet/"
 ---
 Here’s a handy resource providing BEM-based naming suggestions for some of the most common web components.
----
 
 It includes sensible BEM naming for such common components as:
 

--- a/posts/2020-04-07-finding-participants-for-user-research-service-manual-govuk.md
+++ b/posts/2020-04-07-finding-participants-for-user-research-service-manual-govuk.md
@@ -6,7 +6,6 @@ tags: [link, research, ux, a11y]
 linkTarget: "https://www.gov.uk/service-manual/user-research/find-user-research-participants"
 ---
 > It’s also important to do research with all the different kinds of people who may need your service, including those who: have disabilities or use assistive technologies; have limited digital skills or poor literacy; and may need help to use your service.
----
 
 Useful advice regarding user research from GOV.uk covering how to define participant criteria, find participants for research and handle incentives. 
 

--- a/posts/2020-04-10-several-people-are-solving-chriszettercom.md
+++ b/posts/2020-04-10-several-people-are-solving-chriszettercom.md
@@ -6,7 +6,6 @@ tags: [link, crosswords, game, puzzle, javascript, react, websockets]
 linkTarget: "https://multicrosser.chriszetter.com/"
 ---
 > I wanted there to be an easy way to complete crosswords together that didn’t need people to pass a phone back and forth or for a copy of the crossword to be made in a shared Google Spreadsheet.
----
 
 _Several People are Solving_ is a lovely [React app](https://github.com/zetter/react-crossword) which started as a fork of The Guardian’s _Frontend_ repo in order to further develop their crossword component.
 

--- a/posts/2020-04-11-grepapp.md
+++ b/posts/2020-04-11-grepapp.md
@@ -6,6 +6,5 @@ tags: [link, github, development, search, tool]
 linkTarget: "https://grep.app/"
 ---
 > grep.app searches code from over a half million public repositories on GitHub.
----
 
 This could be useful when you’re struggling to use a certain new CSS property, or npm package, and want to see how other programmers are using it.

--- a/posts/2020-04-12-tooled-up-a-brief-history-of-saas-tools-weve-loved-and-lost-freeagent-grinding-gears-blog.md
+++ b/posts/2020-04-12-tooled-up-a-brief-history-of-saas-tools-weve-loved-and-lost-freeagent-grinding-gears-blog.md
@@ -6,6 +6,5 @@ tags: [link, tool, notion, humio, freeagent, remote]
 linkTarget: "https://engineering.freeagent.com/2020/04/03/tooled-up-a-brief-history-of-saas-tools-weve-loved-and-lost/"
 ---
 > I thought it might be interesting to look back through the years at how the tools in Engineering have changed as our company has grown from 3 to over 240 (and engineering to over 100), and to give a shout out to (some of!) those tools that we consider crucial to our workflow today – especially in these most unusual times where most of the world is working remotely.
----
 
 A great insight from FreeAgent CTO, Olly Heady, describing how the engineering team have benefitted from tools such as G Suite (Google Apps), Github, Trello, Datadog, Humio and Notion.

--- a/posts/2020-04-17-jeremy-keith-weve-ruined-the-web-heres-how-we-fix-it-this-is-hcd.md
+++ b/posts/2020-04-17-jeremy-keith-weve-ruined-the-web-heres-how-we-fix-it-this-is-hcd.md
@@ -9,7 +9,6 @@ During the COVID situation, people have an urgent need to access critical inform
 
 Here’s a brilliant discussion between [Gerry McGovern](https://gerrymcgovern.com/) and [Jeremy Keith](https://adactio.com/) on that problem, suggesting tactics to help fix things such as performance budgets, introducing tactics at the design stage to mimic slow connections and other access constraints, optimising for return visits, progressive enhancement and more.
 
----
 
 Loved this! 
 

--- a/posts/2020-04-19-maxboeckresume-an-online-resume.md
+++ b/posts/2020-04-19-maxboeckresume-an-online-resume.md
@@ -6,7 +6,6 @@ tags: [link, print, resume, cv, spellcheck, netlify, 11ty]
 linkTarget: "https://github.com/maxboeck/resume"
 ---
 A beautiful, responsive, print-friendly résumé template from [Max](https://mxb.dev/).
----
 
 Some points of note:
 

--- a/posts/2020-04-26-an-ebook-boilerplate-or-go-make-things.md
+++ b/posts/2020-04-26-an-ebook-boilerplate-or-go-make-things.md
@@ -6,7 +6,6 @@ tags: [link, ebook, book, publishing, markdown, everylayout]
 linkTarget: "https://gomakethings.com/an-ebook-boilerplate/"
 ---
 > My ebook boilerplate is a command-line script that uses Pandoc, wkhtmltopdf, and Calibre to compile all of the files, syntax highlight code snippets, and automatically generate all of the file formats.
----
 
 I’ve recently been discussing with [Clair](https://www.clairirwinphotography.com/) some options for publishing an ebook, which reminded me of this.
 

--- a/posts/2020-05-24-modern-css-solutions.md
+++ b/posts/2020-05-24-modern-css-solutions.md
@@ -6,6 +6,5 @@ tags: [link, development, buttons, css, images, dropdown, navigation, responsive
 linkTarget: "https://moderncss.dev/"
 ---
 > Modern CSS Solutions for Old CSS Problems
----
 
 Stephanie Eckles with a beautifully presented series of articles on how to use modern CSS to tackle some of the enduring challenges of web development including dropdown navigation, centring and styling buttons.

--- a/posts/2020-05-26-how-to-optimise-performance-when-using-googlehosted-fonts-on-css-wizardry.md
+++ b/posts/2020-05-26-how-to-optimise-performance-when-using-googlehosted-fonts-on-css-wizardry.md
@@ -6,7 +6,6 @@ tags: [link, performance, development, web, fonts, google, preload, preconnect]
 linkTarget: "https://csswizardry.com/2020/05/the-fastest-google-fonts/"
 ---
 > A combination of asynchronously loading CSS, asynchronously loading font files, opting into FOFT, fast-fetching asynchronous CSS files, and warming up external domains makes for an experience several seconds faster than the baseline.
----
 
 Harry Roberts suggests that, while self-hosting your web fonts is likely to be the overall best solution to performance and availability problems, we’re able to design some fairly resilient measures to help mitigate a lot of these issues when using Google Fonts.
 

--- a/posts/2020-06-28-striking-a-balance-between-native-and-custom-select-elements-on-csstricks.md
+++ b/posts/2020-06-28-striking-a-balance-between-native-and-custom-select-elements-on-csstricks.md
@@ -6,6 +6,5 @@ tags: [link, development, select, html, javascript, css, a11y, progressiveenhanc
 linkTarget: "https://css-tricks.com/striking-a-balance-between-native-and-custom-select-elements/"
 ---
 > We’re not going to try to replicate everything that the browser does by default with a native select element. We’re going to literally use a select element when any assistive tech is used. But when a mouse is being used, we’ll show the styled version and make it function as a select element.
----
 
 This custom-styled select solution satisfies those who insist on a custom component but retains all the built-in accessibility we get from native form controls. I also really like the use of a `@media (hover: hover)` media query to detect an environment with hover (such as a computer with a mouse rather than a mobile browser on a handheld device).

--- a/posts/2020-06-30-blokk-the-new-and-better-wireframing-font.md
+++ b/posts/2020-06-30-blokk-the-new-and-better-wireframing-font.md
@@ -6,7 +6,6 @@ tags: [link, ux, wireframes, typeface]
 linkTarget: "http://www.blokkfont.com/"
 ---
 > BLOKK is a font for quick mock-ups and wireframing for clients who do not understand latin.
----
 
 A cool idea here, which gives you “block” versions of the words in your _lorem ipsum_ text, at the same width.
 

--- a/posts/2020-07-14-debouncing-vs-throttling-with-vanilla-js-on-go-make-things.md
+++ b/posts/2020-07-14-debouncing-vs-throttling-with-vanilla-js-on-go-make-things.md
@@ -10,7 +10,6 @@ Chris explains how debouncing and throttling are two related but different techn
 With throttling, you run a function immediately, then wait a specified amount of time before running it again. Any additional attempts to run it before that time period is over are ignored.
 
 With debouncing, after the relevant event fires a specified time period must pass _uninterrupted_ in order for your function to run. When the time period has passed uninterrupted, that last attempt to run the function is the one that runs, with any previous attempts ignored.
----
 
 You might _debounce_ code in event handlers for _scroll_ events to run when the user is completely done scrolling so as not to negatively affect browser performance and user experience.
 

--- a/posts/2020-07-25-adactio-journalaccessibility.md
+++ b/posts/2020-07-25-adactio-journalaccessibility.md
@@ -8,6 +8,5 @@ linkTarget: "https://adactio.com/journal/17132"
 Here’s [Jeremy Keith](https://adactio.com/), making the moral case for accessible websites and why we shouldn’t use “you can make more money by not turning people away” as an argument:
 
 > I understand how it’s useful to have the stats and numbers to hand should you need to convince a sociopath in your organisation, but when numbers are used as the justification, you’re playing the numbers game from then on. You’ll probably have to field questions like ”Well, how many screen reader users are visiting our site anyway?” (To which the correct answer is “I don’t know and I don’t care” – even if the number is 1, the website should still be accessible because <em>it’s the right thing to do</em>.)
----
 
 (via @adactio)

--- a/posts/2020-08-02-how-to-create-accessible-subtitles-on-go-make-things.md
+++ b/posts/2020-08-02-how-to-create-accessible-subtitles-on-go-make-things.md
@@ -6,7 +6,6 @@ tags: [link, a11y]
 linkTarget: "https://gomakethings.com/how-to-create-accessible-subtitles/"
 ---
 Here’s Chris Ferdinandi, introducing the ARIA <code>doc-subtitle</code> role.
----
 
 He sets the scene by describing the popular design pattern where we have a title with a subtitle directly underneath, and that subtitle is set to be visually distinct via its font size being larger than the body text while remaining smaller than the main heading. Developers have typically marked up the subtitle using either another heading element, or a dedicated class. He suggests that the former is bad because headings in HTML are for conveying structure (with the inference that a subtitle is not structural) while the latter is suboptimal because it provides sighted users with additional information that visually impaired users don’t get.
 

--- a/posts/2020-08-03-im-jack-mcdade-and-im-tired-of-boring-websites.md
+++ b/posts/2020-08-03-im-jack-mcdade-and-im-tired-of-boring-websites.md
@@ -6,7 +6,6 @@ tags: [link, design, web, fun, inspiration, audio]
 linkTarget: "https://jackmcdade.com/"
 ---
 > I’m Jack McDade and I’m tired of boring websites.
----
 
 So many fun touches in the design for Jack’s personal website! It gave me plenty of chuckles while browsing over the weekend.
 

--- a/posts/2020-08-07-sass-and-clamp-on-adactio-journal.md
+++ b/posts/2020-08-07-sass-and-clamp-on-adactio-journal.md
@@ -8,7 +8,6 @@ linkTarget: "https://adactio.com/journal/16887"
 Given what we can now do with CSS, do we still need Sass?
 
 > Sass was the hare. CSS is the tortoise. Sass blazed the trail, but now native CSS can achieve much the same result.
----
 
 Jeremy’s post starts by talking about the new CSS `clamp` function and how it can be used for scalable type, then veers into a question of whether we still need Sass or if modern CSS now covers our needs.
 

--- a/posts/2020-08-08-color-theme-switcher-on-mxbdev.md
+++ b/posts/2020-08-08-color-theme-switcher-on-mxbdev.md
@@ -6,6 +6,5 @@ tags: [link, development, css, javascript, tool, nunjucks, customproperties, 11t
 linkTarget: "https://mxb.dev/blog/color-theme-switcher/"
 ---
 Max shows us how to build a colour theme switcher to let users customise your website. He uses a combination of Eleventy, JSON, Nunjucks with macros, a data attribute on the html element, CSS custom properties and a JavaScript based switcher.
----
 
 Thanks, [Max](https://twitter.com/mxbck)!

--- a/posts/2020-08-08-simplest-way-to-load-css-async.md
+++ b/posts/2020-08-08-simplest-way-to-load-css-async.md
@@ -6,7 +6,6 @@ tags: [link, performance, development, css, javascript, tool, nunjucks, custompr
 linkTarget: "https://www.filamentgroup.com/lab/load-css-simpler/"
 ---
 Scott Jehl of Filament Group demonstrates a one-liner technique for loading external CSS files without them delaying page rendering.
----
 
 While this isn’t really necessary in situations where your (minified and compressed) CSS is small, say 14k or below, it could be useful when working with large CSS files and want to deliver critical CSS separately and the rest asynchronously.
 

--- a/posts/2020-08-08-three-css-alternatives-to-javascript-navigation-on-csstricks.md
+++ b/posts/2020-08-08-three-css-alternatives-to-javascript-navigation-on-csstricks.md
@@ -8,6 +8,5 @@ linkTarget: "https://css-tricks.com/three-css-alternatives-to-javascript-navigat
 In general this is a decent article on non-JavaScript-based mobile navigation options, but what I found most interesting is the idea of having a separate _page_ for your navigation menu (at the URL /menu, for example). 
 
 > Who said navigation has to be in the header of every page? If your front end is extremely lightweight or if you have a long list of menu items to display in your navigation, the most practical method might be to create a separate page to list them all.
----
 
 I also noted that the article describes a method where you can “spoof” a slide-in _hamburger_ menu without JS by using the checkbox hack. I once coded a similar “HTML and CSS -only” hamburger menu, but opted instead to use the `:target` pseudo-class in combination with the adjacent sibling selector, [as described by Chris Coyier back in 2012](https://css-tricks.com/off-canvas-menu-with-css-target/).

--- a/posts/2020-08-09-hero-patterns-free-repeatable-svg-background-patterns-for-your-web-projects.md
+++ b/posts/2020-08-09-hero-patterns-free-repeatable-svg-background-patterns-for-your-web-projects.md
@@ -8,6 +8,5 @@ linkTarget: "http://www.heropatterns.com/"
 From Steve Schoger:
 
 > A collection of repeatable SVG background patterns for you to use on your web projects.
----
 
 This was recommended by Chris Coyier in his post [Websites to Generate SVG Patterns](https://css-tricks.com/websites-generate-svg-patterns/).

--- a/posts/2020-08-09-rodney-ps-jazz-funk-on-bbc-four.md
+++ b/posts/2020-08-09-rodney-ps-jazz-funk-on-bbc-four.md
@@ -6,6 +6,5 @@ tags: [link, music, jazzfunk, culture, tv]
 linkTarget: "https://www.bbc.co.uk/programmes/m000l426"
 ---
 UK rap legend Rodney P reveals how the first generation of British-born black kids was inspired by the avant-garde musical fusions of black America in the 70s to lay the foundations of modern-day multiculturalism by creating the first black British music culture with the jazz-funk movement.
----
 
 A brilliant documentary featuring great music from Pharoah Sanders, War, Hi-Tension, Ronnie Laws and more.

--- a/posts/2020-08-09-signin-form-best-practices-on-webdev.md
+++ b/posts/2020-08-09-signin-form-best-practices-on-webdev.md
@@ -6,10 +6,9 @@ tags: [link, development, a11y, security, forms, aria]
 linkTarget: "https://web.dev/sign-in-form-best-practices/#new-password"
 ---
 Sam Dutton advises how to use cross-platform browser features to build sign-in forms that are secure, accessible and easy to use.
----
 
 The tips of greatest interest to me were:
 
-- on using `autocomplete="new-password"` on registration forms and `autocomplete="current-password"` on sign-in forms to tap into browser password suggestion and password manager features; 
-- on how best to provide “Show Password” functionality; and 
+- on using `autocomplete="new-password"` on registration forms and `autocomplete="current-password"` on sign-in forms to tap into browser password suggestion and password manager features;
+- on how best to provide “Show Password” functionality; and
 - on using `aria-describedby` when providing guidance on password rules.

--- a/posts/2020-08-10-doing-it-right-podcast-with-dotty-charles.md
+++ b/posts/2020-08-10-doing-it-right-podcast-with-dotty-charles.md
@@ -8,7 +8,6 @@ linkTarget: "https://doingitright.podbean.com/e/doing-it-right-dotty-charles/"
 An interview with Ashley ‘Dotty’ Charles, a writer and broadcaster, on the topic of online outrage.
 
 > By shouting about the little things, are we neglecting to talk about the bigger issues in modern society? We discuss performative outrage, the role of the social media provocateur and the strange case of Rachel Dolezal.
----
 
 I really enjoyed this. It totally chimed with how I currently feel about the state of online discourse, and Dotty has some great ideas and insights. I’ve already bought [her book, Outraged](https://www.waterstones.com/book/outraged/ashley-dotty-charles/9781526605030) and am looking forward to reading that soon.
 

--- a/posts/2020-08-16-jakarta-sans-typeface.md
+++ b/posts/2020-08-16-jakarta-sans-typeface.md
@@ -6,6 +6,5 @@ tags: [link, typeface, typography, opensource]
 linkTarget: "https://tokotype.github.io/plusjakarta-sans/#page-top"
 ---
 Jakarta Sans is a nice-looking Open Source (so free to use) typeface which I reckon I could use at some point. 
----
 
 (via [@css](https://twitter.com/css))

--- a/posts/2020-08-23-create-a-line-break-while-maintaining-inline-status-on-piccalilli.md
+++ b/posts/2020-08-23-create-a-line-break-while-maintaining-inline-status-on-piccalilli.md
@@ -6,7 +6,6 @@ tags: [link, css, development, inline, block, whitespace, break]
 linkTarget: "https://piccalil.li/quick-tip/create-a-line-break-while-maintaining-inline-status/"
 ---
 > Sometimes you want to create a line break after an inline element, while retaining that inline element’s inline status.
----
 
 A lovely trick from Andy Bell for breaking after an inline element (such as a form label) using a pseudo-element and the `white-space` property, so that we can avoid setting the element to `display: block` (thereby becoming full-width etc) when we don’t want that.
 

--- a/posts/2020-08-23-introducing-rome.md
+++ b/posts/2020-08-23-introducing-rome.md
@@ -6,6 +6,5 @@ tags: [link, tool, webpack, javascript, babel, jest, testing]
 linkTarget: "https://romefrontend.dev/blog/2020/08/08/introducing-rome.html"
 ---
 > We’re excited to announce the first beta release and general availability of the Rome linter for JavaScript and TypeScript. This is the beginning of an entire suite of tools. Rome is not only a linter, but also a compiler, bundler, test runner, and more, for JavaScript, TypeScript, HTML, JSON, Markdown, and CSS. We aim to unify the entire frontend development toolchain.
----
 
 A very ambitious project from the creator of Babel.

--- a/posts/2020-09-05-the-difference-between-arialabel-and-arialabelledby-tink-leonie-watson.md
+++ b/posts/2020-09-05-the-difference-between-arialabel-and-arialabelledby-tink-leonie-watson.md
@@ -6,7 +6,6 @@ tags: [link, a11y, development, aria]
 linkTarget: "https://tink.uk/the-difference-between-aria-label-and-aria-labelledby/"
 ---
 > The `aria-label` and `aria-labelledby` attributes do the same thing but in different ways. Sometimes the two attributes are confused and this has unintended results. This post describes the differences between them and how to choose the right one.
----
 
 The key takeaways for me were:
 

--- a/posts/2020-09-19-ittybitty.md
+++ b/posts/2020-09-19-ittybitty.md
@@ -8,7 +8,6 @@ linkTarget: "https://itty.bitty.site/edit"
 Here’s an interesting tool for creating and sharing small-ish web pages without having to build a website or organise hosting.
 
 > itty.bitty takes html (or other data), compresses it into a URL fragment, and provides a link that can be shared. When it is opened, it inflates that data on the receiver’s side.
----
 
 While I find this idea interesting, I’m not yet 100% sure how or when I’ll use it! I’m sure it’ll come in handy at some point, though.
 

--- a/posts/2020-09-19-when-there-is-no-content-between-headings.md
+++ b/posts/2020-09-19-when-there-is-no-content-between-headings.md
@@ -8,7 +8,6 @@ linkTarget: "https://hiddedevries.nl/en/blog/2020-09-05-when-there-is-no-content
 Hidde de Vries explains why an HTML heading should never be immediately followed by another.
 
 > When you use a heading element, you set the expectation of content.
----
 
 I have always prided myself on using appropriate, semantic HTML, however it’s recently become clear to me that there’s one thing I occasionally do wrongly. Sometimes I follow a page’s title (usually an `h1` element) with a subtitle which I mark up as an `h2`. I considered this the right element for the job and my choice had nothing to do with aesthetics. 
 

--- a/posts/2020-10-02-a-guide-to-the-state-of-print-stylesheets-in-2018-smashing-magazine.md
+++ b/posts/2020-10-02-a-guide-to-the-state-of-print-stylesheets-in-2018-smashing-magazine.md
@@ -6,7 +6,6 @@ tags: [link, print, css, development, mediaqueries, designsystems]
 linkTarget: "https://www.smashingmagazine.com/2018/05/print-stylesheets-in-2018/"
 ---
 Rachel Andrew explains how to write CSS for a nicely optimised printed page that uses a minimum of ink and paper and ensures that content is easy to read.
----
 
 I really like the section on Workflow that compares the options of 
 1. organising your print styles as a separate stylesheet loaded via a `<link>` in the `<head>` (this is the “traditional” approach); versus

--- a/posts/2020-11-02-bookshop-this-is-revolutionary-on-the-guardian.md
+++ b/posts/2020-11-02-bookshop-this-is-revolutionary-on-the-guardian.md
@@ -6,6 +6,5 @@ tags: [link, books, shopping]
 linkTarget: "https://www.theguardian.com/books/2020/nov/02/this-is-revolutionary-new-online-bookshop-unites-indies-to-rival-amazon"
 ---
 > Bookshop was dreamed up by the writer and co-founder of Literary Hub, Andy Hunter. It allows independent bookshops to create their own virtual shopfront on the site, with the stores receiving the full profit margin – 30% of the cover price – from each sale. All customer service and shipping are handled by Bookshop and its distributor partners, with titles offered at a small discount and delivered within two to three days.
----
 
 (via [@RyanSoulbhoy](https://twitter.com/RyanSoulbhoy))

--- a/posts/2020-11-16-article-layout-with-css-grid.md
+++ b/posts/2020-11-16-article-layout-with-css-grid.md
@@ -8,7 +8,6 @@ linkTarget: "https://mastery.games/post/article-grid-layout/"
 Very clever responsive `<article>` layout  (with gutters and breakout images) achieved using CSS Grid, `minmax()`, the `ch` unit and a minimum of fuss. It scales automatically from narrow to wide viewports with no `auto` margins, `max-width` or media query manual overrides in sight.
 
 > For the blog post page (the page you're looking at right now) I wanted a mobile-friendly layout where the text was centered and readable, where the images/code examples are wide.
----
 
 The gist of it is this:
 
@@ -28,6 +27,6 @@ The gist of it is this:
 
 Simple and deadly.
 
-I can potentially see this as a pattern, or [layout primitive](https://every-layout.dev/rudiments/composition/), rather than just as something you might use at the top-level of the page for overall layout. I’m looking forward to trying it out! 
+I can potentially see this as a pattern, or [layout primitive](https://every-layout.dev/rudiments/composition/), rather than just as something you might use at the top-level of the page for overall layout. I’m looking forward to trying it out!
 
 (via [Ahmad Shadeed](https://mastery.games/post/article-grid-layout/))

--- a/posts/2020-11-17-breaking-out-with-css-grid-layout-on-cloudfourcom.md
+++ b/posts/2020-11-17-breaking-out-with-css-grid-layout-on-cloudfourcom.md
@@ -6,7 +6,6 @@ tags: [link, cssgrid, breakout, images, responsive, layout, article, minmax]
 linkTarget: "https://cloudfour.com/thinks/breaking-out-with-css-grid-layout/"
 ---
 While [bookmarking the mastery.games article](https://fuzzylogic.me/posts/2020-11-16-article-layout-with-css-grid/) yesterday, I started getting the feeling that something was awfully familiar. It was! I’ve seen this layout before – from Tyler Sticka back in 2017 to be precise – but failed to bookmark it at the time.
----
 
 Here, then, is the original and still the best CSS Grid “article with breakout images” layout! 
 

--- a/posts/2020-12-03-creating-websites-with-prefersreduceddata-on-polypane.md
+++ b/posts/2020-12-03-creating-websites-with-prefersreduceddata-on-polypane.md
@@ -6,7 +6,6 @@ tags: [link, performance, a11y, mediaqueries, connection, css, javascript]
 linkTarget: "https://polypane.app/blog/creating-websites-with-prefers-reduced-data/"
 ---
 > Even though more and more people get access to the internet every day, not all of them have fast gigabit connections or unlimited data. Using the media query prefers-reduced-data we can keep our sites accessible to everyone.
----
 
 I’ve long wondered if there could be a way to tailor content to a user based on the speed of their internet connection, especially when considering features like responsive images. This looks like it might be the way to do that (although browser support is currently non-existent). It also allows us to respect the user’s wishes on how much data / battery life etc they’re willing to spare for your website.
 

--- a/posts/2020-12-04-small-axe-series-1-red-white-and-blue-on-bbc-iplayer.md
+++ b/posts/2020-12-04-small-axe-series-1-red-white-and-blue-on-bbc-iplayer.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.bbc.co.uk/iplayer/episode/m000pzmb/small-axe-series-1-r
 One of several fantastic films from Oscar-winning director Steve McQueen (_12 Years a Slave_) described as “Love letters to black resilience and triumph in London's West Indian community. Vivid stories of hard-won victories in the face of racism.”
 
 This one tells the story of Leroy Logan, a young black man who joins the police in an attempt to effect change “from the inside” as a consequence of seeing his father assaulted by police officers. He is faced with both his father’s disapproval and institutional racism within the police ranks.
----
 
 A  brilliant and powerful film which left its mark on me.
 

--- a/posts/2020-12-07-a11y-is-not-extra-effort-for-people-with-disabilities.md
+++ b/posts/2020-12-07-a11y-is-not-extra-effort-for-people-with-disabilities.md
@@ -10,7 +10,6 @@ Strong agree with these sentiments regarding accessibility expressed by Max Böc
 From Andrey:
 
 > If you’re building UI, it’s your responsibility to make it work for everyone. Clients often tell me “we don’t care about accessibility” but in reality they do want keyboard support at the very least. So I just build my UI in a way it works without discussing it. It’s my job.
----
 
 To which Max replies:
 

--- a/posts/2021-01-03-big-picture-performance-analysis-using-lighthouse-parade-on-cloud-four.md
+++ b/posts/2021-01-03-big-picture-performance-analysis-using-lighthouse-parade-on-cloud-four.md
@@ -8,7 +8,6 @@ linkTarget: "https://cloudfour.com/thinks/big-picture-performance-analysis-using
 I like the sound of this performance analysis tool from the clever folks at [Cloud Four](https://cloudfour.com/), especially because it covers your entire site rather than just a single page.
 
 > Lighthouse Parade is a Node.js command line tool that crawls a domain and gathers lighthouse performance data for every page. With a single command, the tool will crawl an entire site, run a Lighthouse report for each page, and then output a spreadsheet with the aggregated data.
----
 
 It was also easy to run with no local installation, via:
 

--- a/posts/2021-01-03-create-an-automatically-responsive-flexbox-gallery-on-eggheadio.md
+++ b/posts/2021-01-03-create-an-automatically-responsive-flexbox-gallery-on-eggheadio.md
@@ -6,6 +6,5 @@ tags: [link, development, css, codepen, objectfit, images, flexbox, layout, intr
 linkTarget: "https://egghead.io/lessons/flexbox-create-an-automatically-responsive-flexbox-gallery"
 ---
 Here’s a lovely intrinsically responsive (no media queries) photo gallery solution from [Stephanie Eckles](https://twitter.com/5t3ph). It can accommodate differently sized images and achieves its layout by a combination of flexbox features (`flex-wrap`, `flex-basis`) and by applying `object-fit: cover` to photos to make them fully _cover_ their parent list items.
----
 
 [Here’s my crack at it on Codepen.](https://codepen.io/fuzzylogicx/pen/QWKmBOp)

--- a/posts/2021-01-04-merch-table.md
+++ b/posts/2021-01-04-merch-table.md
@@ -6,6 +6,5 @@ tags: [link, tool, music, bandcamp, spotify]
 linkTarget: "https://hypem.com/merch-table"
 ---
 A neat online tool (with a positive goal) which lets you paste in a link to one of your Spotify playlists then lets you know which of the tracks or albums are available to buy on Bandcamp.
----
 
 > Support the artists you listen to by buying their stuff.

--- a/posts/2021-01-05-bbc-gel-or-the-lessons-learnt-creating-a-design-system-for-bbc-online.md
+++ b/posts/2021-01-05-bbc-gel-or-the-lessons-learnt-creating-a-design-system-for-bbc-online.md
@@ -6,6 +6,5 @@ tags: [link, designsystems, bbc, stack, layout]
 linkTarget: "https://www.bbc.co.uk/gel/articles/creating-a-design-system-for-bbc"
 ---
 Interesting insight into the BBC design system and the five areas it’s split into: Foundations, Components, Layout Components (including Stack, Grid etc) Levers and Containers.
----
 
 (via [@piccalilli_](https://twitter.com/piccalilli_))

--- a/posts/2021-01-05-newsletters-by-robin-rendle.md
+++ b/posts/2021-01-05-newsletters-by-robin-rendle.md
@@ -6,7 +6,6 @@ tags: [link, viewportunits, story, blog, personalsites, css, javascript, height,
 linkTarget: "https://www.robinrendle.com/essays/newsletters"
 ---
 A fantastic so-called “Scroll Story” from Robin Rendle. In his own words it’s “an elaborate blog post where I rant about a thing” however given the beautiful typography, layout and illustrations on show I think he’s selling it a little short!
----
 
 The content of this “story” is pretty interesting – Robin laments the fact that web authors often need newsletters, or to “spam social media” in order to publicise articles on their websites, because most people don’t use RSS (awareness is too low and barriers to entry too great).
 

--- a/posts/2021-01-06-a-utility-class-for-covering-elements-on-css-in-real-life.md
+++ b/posts/2021-01-06-a-utility-class-for-covering-elements-on-css-in-real-life.md
@@ -6,7 +6,6 @@ tags: [link, css, development, cssgrid, logicalproperties, inset, positioning, u
 linkTarget: "https://css-irl.info/a-utility-class-for-covering-elements/"
 ---
 Need to overlay one HTML element on top of and fully covering another, such as a heading with translucent background on top of an image? Michelle Barker has us covered with this blog post in which she creates an `overlay` utility to handle this. She firstly shows how it can be accomplished with positioning, then modernises her code using the `inset` CSS logical property, before finally demonstrating a neat CSS Grid based approach.
----
 
 I like this and can see myself using it – especially the Grid-based version because these days I try to avoid absolute positioning and use modern layout tools instead where possible. 
 

--- a/posts/2021-01-07-your-interview-test-for-junior-developer-from-bruce-lawson-on-twitter.md
+++ b/posts/2021-01-07-your-interview-test-for-junior-developer-from-bruce-lawson-on-twitter.md
@@ -6,7 +6,6 @@ tags: [link, development, interviews, jobs, humour, twitter]
 linkTarget: "https://twitter.com/brucel/status/1186931675978182656"
 ---
 > "Ok, as part of your interview test for junior developer, we want you to put some words, an image and some links onto a webpage. We use Node, Docker, Kubernetes, React, Redux, Puppeteer, Babel, Bootstrap, Webpack, `<div>` and `<span>`. Go!"
----
 
 Bruce Lawson nicely illustrates how ridiculous many job adverts for web developers are. This (see video) never fails to crack me up. It’s funny ‘cos it’s true! 
 

--- a/posts/2021-01-16-cheating-entropy-with-native-web-technologies-on-jim-nielsens-weblog.md
+++ b/posts/2021-01-16-cheating-entropy-with-native-web-technologies-on-jim-nielsens-weblog.md
@@ -14,7 +14,6 @@ This is why, over years of building for the web, I have learned that I can signi
 - Could I author this in CSS instead of choosing a preprocessor?
 
 </blockquote>
----
 
 Fantastic post from Jim Neilson about how your future self will thank you if you keep your technology stack simple now. 
 

--- a/posts/2021-01-16-visualsitemaps-autogenerate-beautiful-sitemaps-and-screenshots.md
+++ b/posts/2021-01-16-visualsitemaps-autogenerate-beautiful-sitemaps-and-screenshots.md
@@ -8,6 +8,5 @@ linkTarget: "https://visualsitemaps.com/"
 A great tool for automatically generating a visual sitemap (_visual_ because it attaches a screenshot to each node) for any given website.
 
 > Simply enter a URL and get a thumbnail-based visual architecture of the entire site.
----
 
 You can even have it [crawl a password-protected website](https://support.visualsitemaps.com/en/articles/3673081-how-to-crawl-a-password-protected-private-website).

--- a/posts/2021-01-18-assistiv-labs.md
+++ b/posts/2021-01-18-assistiv-labs.md
@@ -8,7 +8,6 @@ linkTarget: "https://assistivlabs.com/"
 A tool for testing how accessible your experience is on various assistive technologies – perhaps “like BrowserStack but for screen readers”?
 
 > Assistiv Labs remotely connects you to real assistive technologies, like NVDA, VoiceOver, and TalkBack, using any modern web browser. 
----
 
 I use a Mac for development which means that when I do screen reader testing [I use the Mac’s VoiceOver tool](https://fuzzylogic.me/posts/my-screen-reader-cheatsheet/). However the majority of screen reader users are using NVDA via Firefox on a PC. Perhaps this tool might let me test on that stack without buying a PC.
 

--- a/posts/2021-01-23-comparing-browsers-for-responsive-design-on-csstricks.md
+++ b/posts/2021-01-23-comparing-browsers-for-responsive-design-on-csstricks.md
@@ -8,6 +8,5 @@ linkTarget: "https://css-tricks.com/comparing-browsers-for-responsive-design/"
 Chris Coyier checks out Sizzy, Polypane et al and decides which suits him best.
 
 > There are a number of these desktop apps where the goal is showing your site at different dimensions all at the same time. So you can, for example, be writing CSS and making sure it’s working across all the viewports in a single glance.
----
 
 I noticed Andy Bell recommending [Sizzy](https://sizzy.co/) so I’m interested to give it a go. Polypane got Chris’s vote, but is a little more expensive at ~£8 per month versus ~£5, so I should do a little shoot-out of my own.

--- a/posts/2021-01-24-adactio-journalaccessible-interactions.md
+++ b/posts/2021-01-24-adactio-journalaccessible-interactions.md
@@ -6,7 +6,6 @@ tags: [link, web, development, modal, javascript, a11y, accessibility, aria, fra
 linkTarget: "https://adactio.com/journal/17546"
 ---
 Jeremy Keith takes us through his thought process regarding the choice of link or `button` when planning accessible interactive disclosure elements.
----
 
 A `button` is generally a solid choice as it’s built for general interactivity and carries the expectation that when activated, something somewhere happens. However in some cases a link might be appropriate, for example when the _trigger_ and _target content_ are relatively far apart in the DOM and we feel the need move the user to the target / give it focus.
 

--- a/posts/2021-01-24-easy-sass-extension-for-visual-studio-code-from-wojciechsura-on-github.md
+++ b/posts/2021-01-24-easy-sass-extension-for-visual-studio-code-from-wojciechsura-on-github.md
@@ -6,7 +6,6 @@ tags: [link, tool, extension, vscode, sass, css, build, dependencies]
 linkTarget: "https://github.com/wojciechsura/easysass"
 ---
 > Automatically compiles SASS/SCSS files to .css and .min.css upon saving. You may also quickly compile all SCSS/SASS files in your project.
----
 
 As I consider different ways in which to simplify my development stack and avoid excess tooling ([much like Michelle Barker did](https://css-irl.info/building-a-dependency-free-site/)), this might be worth a look. 
 

--- a/posts/2021-01-24-howto-create-accessible-forms-the-a11y-project.md
+++ b/posts/2021-01-24-howto-create-accessible-forms-the-a11y-project.md
@@ -5,14 +5,13 @@ description: "Five bite-sized and practical chunks of advice for creating access
 tags: [link, web, development, a11y, accessibility, focus, forms]
 linkTarget: "https://www.a11yproject.com/posts/2020-09-19-how-to-write-accessible-forms/"
 ---
-Here are five bite-sized and practical chunks of advice for creating accessible forms. 
+Here are five bite-sized and practical chunks of advice for creating accessible forms.
 
 1. Always label your inputs.
 1. Highlight input elements on focus.
 1. Break long forms into smaller sections/pages.
 1. Provide error messages (rather than just colour-based indicators)
 1. Avoid horizontal layout forms unless necessary.
----
 
 I already apply some of these principles, but even within those I found some interesting takeaways. For example, the article advises that when labelling your inputs it’s better not to nest the input within a `<label>` because some assistive technologies (such as Dragon NaturallySpeaking) don’t support it.
 
@@ -27,6 +26,6 @@ input:focus {
 }
 ```
 
-</figure> 
+</figure>
 
 (via [@adactio](https://twitter.com/adactio))

--- a/posts/2021-01-24-meta-tags-preview-edit-and-generate.md
+++ b/posts/2021-01-24-meta-tags-preview-edit-and-generate.md
@@ -6,6 +6,5 @@ tags: [link, tool, slack, facebook, twitter, google, web, development]
 linkTarget: "https://metatags.io/"
 ---
 A handy tool which lets you type in a URL then inspects that page’s meta tags and shows you how it will be presented on popular websites. 
----
 
 This is really useful for testing how an article will look as a Google search result or when shared on Facebook, Slack and Twitter based on different meta tag values.

--- a/posts/2021-01-24-minimalist-container-queries.md
+++ b/posts/2021-01-24-minimalist-container-queries.md
@@ -8,7 +8,6 @@ linkTarget: "https://codepen.io/scottjehl/pen/NWrdRQv"
 Scott Jehl’s experimental take on a container/element query aimed at letting us set responsive styles for our elements based on their immediate context rather than that of the viewport.
 
 > I made a quick and minimal take on approximating Container/Element Queries using a web component and basic CSS selectors.
----
 
 The idea is that for any given instance of the `<c-q>` custom element / web component you would define a scoped custom property which sets the pixel min-widths you’re interested in, like so:
 

--- a/posts/2021-01-24-super-turbo-logo-servicetm-on-simplebits.md
+++ b/posts/2021-01-24-super-turbo-logo-servicetm-on-simplebits.md
@@ -6,6 +6,5 @@ tags: [link, logo, design, branding]
 linkTarget: "https://simplebits.com/pages/work"
 ---
 > I’m available for limited logo design projects. Just the logo. Limited back-and-forth. Reasonable price. With a particular focus on elevating small businesses that can’t or don’t want to hire a full-blown agency. Let’s keep this simple.
----
 
 I’m a long-time fan of Dan Cederholm and his work. If I wanted a new logo, this is where I’d go!

--- a/posts/2021-01-24-the-race-for-a-vaccine-on-bbc-one-panorama.md
+++ b/posts/2021-01-24-the-race-for-a-vaccine-on-bbc-one-panorama.md
@@ -6,6 +6,5 @@ tags: [link, coronavirus, vaccine, health, tv]
 linkTarget: "https://www.bbc.co.uk/programmes/m000qdzd"
 ---
 > Panorama tells the inside story of the development of the Oxford vaccine against Covid-19. For the past 11 months, the BBC's medical editor Fergus Walsh followed the team at Oxford University and AstraZeneca, as they designed, developed, manufactured and trialled the vaccine.
----
 
 In the middle of a pretty depressing period, this is fantastic TV about an inspirational scientific effort.

--- a/posts/2021-01-25-robb-owen-independent-creative-developer.md
+++ b/posts/2021-01-25-robb-owen-independent-creative-developer.md
@@ -8,7 +8,6 @@ linkTarget: "https://robbowen.digital/"
 Definite “personal website goals” here in Robb’s beautiful online portfolio and blog.
 
 > From interaction design to scaleable design systems, single-page apps to something more experimental with WebGL. I help awesome people to build ambitious yet accessible web projects - the wilder, the better.
----
 
 Robb combines beautiful typography and colours with fun and smooth animation… and the words ain’t half bad, either.
 

--- a/posts/2021-01-26-complete-guide-to-source-sans-pro-on-beautiful-web-type.md
+++ b/posts/2021-01-26-complete-guide-to-source-sans-pro-on-beautiful-web-type.md
@@ -8,7 +8,6 @@ linkTarget: "https://beautifulwebtype.com/source-sans-pro/"
 At the time of writing, my personal website uses the typeface _Source Sans Pro_ and has done for around two years. I already employ a number of its cool features however this lovely demo page provides further inspiration.
 
 > Source Sans Pro is a versatile typeface designed particularly for user interfaces. Its letterforms are slightly condensed allowing them to fit into tight spaces within a UI, and remain well-defined even at small sizes.
----
 
 I might consider going back to using Source Serif Pro for headings again, too. 
 

--- a/posts/2021-01-26-music-for-programming.md
+++ b/posts/2021-01-26-music-for-programming.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.musicforprogramming.net/"
 Feel like I’m probably really late to discover this website, but here’s “Music for Programming” from Datassette. Hopefully this’ll be of use to fellow programmers who like music, although I daresay you can probably enjoy it if you’re a normal person too.
 
 > Through years of trial and error - skipping around internet radio stations, playing our entire music collections on shuffle, or just hammering single albums on repeat, we have found that the most effective music to aid prolonged periods of intense concentration tends to have a mixture of the following qualities:  Drones, Noise, Fuzz, Field recordings, Vagueness (Hypnagogia), Textures without rhythm…
----
 
 As both a programmer and big fan of [Datassette](http://datassette.net/) (the creator/curator of this website), how did I not know about this sooner?! Anyway, plenty to dive into now.
 

--- a/posts/2021-01-26-use-css-clamp-to-create-a-more-flexible-wrapper-utility-on-piccalilli.md
+++ b/posts/2021-01-26-use-css-clamp-to-create-a-more-flexible-wrapper-utility-on-piccalilli.md
@@ -8,7 +8,6 @@ linkTarget: "https://piccalil.li/quick-tip/use-css-clamp-to-create-a-more-flexib
 Here’s Andy Bell recommending using CSS `clamp()` to control your wrapper/container `width` because it supports setting a preferred value in `vw` to ensure sensible gutters combined with a maximum tolerance in `rem`—all in a single line of code.
 
 > If we use clamp() to use a viewport unit as the ideal and use what we would previously use as the max-width as the clamp’s maximum value, we get a much more flexible setup.
----
 
 The code looks like this:
 

--- a/posts/2021-01-31-source-serif-4.md
+++ b/posts/2021-01-31-source-serif-4.md
@@ -8,6 +8,5 @@ linkTarget: "https://adobe-fonts.github.io/source-serif/"
 Here’s a nice demo page for Source Serif 4 which illustrates its versatility.
 
 > Source Serif is an open-source typeface for setting text in many sizes, weights, and languages. The design of Source Serif represents a contemporary interpretation of the transitional typefaces of Pierre-Simon Fournier. Additionally, Source Serif has been conceived as a friendly companion to Paul D. Hunt’s Source Sans.
----
 
 Back when I first started using Source Sans Pro for text for my personal website, I tried pairing it with Source Serif for headings. It didn’t quite work for me then but the typeface seems to have undergone some changes in the interim and also now comes with a variable font option. I might give it another spin.

--- a/posts/2021-02-02-a-first-look-at-aspectratio-on-csstricks.md
+++ b/posts/2021-02-02-a-first-look-at-aspectratio-on-csstricks.md
@@ -6,7 +6,6 @@ tags: [link, web, development, css, layout, aspectratio, box, images]
 linkTarget: "https://css-tricks.com/a-first-look-at-aspect-ratio/"
 ---
 Chris Coyier takes the new CSS `aspect-ratio` property for a spin and tests how it works in different scenarios.
----
 
 Note that he’s applying it here to elements which do not have an intrinsic aspect-ratio. So, think a container element (`div` or whatever is appropriate) rather than an `img`. This is line with a [Jen’s Simmons’ recent replies to me](https://twitter.com/jensimmons/status/1347583682496892929) when I asked her [whether or not we should apply `aspect-ratio` to an `img`](https://twitter.com/fuzzylogicx/status/1347307685826469894) after she announced [support for `aspect-ratio` in Safari Technical Preview 118](https://twitter.com/jensimmons/status/1347287421633892356).
 

--- a/posts/2021-02-02-vanilla-js-list.md
+++ b/posts/2021-02-02-vanilla-js-list.md
@@ -8,7 +8,6 @@ linkTarget: "https://vanillajslist.com/"
 Here’s Chris Ferdinandi’s curated list of organisations which use vanilla JS to build websites and web apps.
 
 You don’t _need_ a heavyweight JavaScript framework, and vanilla JS _does_ scale.
----
 
 At the time of writing the list includes Marks & Spencer, Selfridges, Basecamp and GitHub.
 

--- a/posts/2021-02-05-design-system-components-recipes-and-snowflakes-on-bradfrostcom.md
+++ b/posts/2021-02-05-design-system-components-recipes-and-snowflakes-on-bradfrostcom.md
@@ -6,7 +6,6 @@ tags: [link, web, development, components, designsystems, composition]
 linkTarget: "https://bradfrost.com/blog/post/design-system-components-recipes-and-snowflakes/"
 ---
 An excellent article from Brad Frost in which he gives us some vocabulary for separating context-agnostic components intended for maximal use from specific variants and one-offs.
----
 
 In light of some recent conversations at work, this was in equal measure interesting, reassuring, and thought-provoking.
 

--- a/posts/2021-02-09-guest-mix-for-multiverse-sessions-december-2020-by-tom-churchill.md
+++ b/posts/2021-02-09-guest-mix-for-multiverse-sessions-december-2020-by-tom-churchill.md
@@ -6,6 +6,5 @@ tags: [link, music, mix, techno, electro, mellow]
 linkTarget: "https://soundcloud.com/tomchurchill/guest-mix-for-multiverse-sessions-december-2020"
 ---
 > Kicking off with an unreleased interlude by yours truly, it covers various shades of techno and electro from artists including @tapesjamaican, @pearsonsound, @reedalerise, @datashat, @legowelt-official, @cygnus and more.
----
 
 Lovely mix of mellow electro and techno vibes by my friend [Tom](https://www.tomchurchill.com/).

--- a/posts/2021-02-11-making-sense-of-atomic-design-molecules-and-organisms-on-future-learn.md
+++ b/posts/2021-02-11-making-sense-of-atomic-design-molecules-and-organisms-on-future-learn.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.futurelearn.com/info/blog/atomic-design-molecules-organ
 From 2015: Alla Kholmatova reflects on the difficulty in choosing between _molecule_ or _organism_ when categorising components using atomic design at FutureLearn. She also provides some handy insights into how they handled it.
 
 > When thinking about complexity of elements, it helps viewing molecules as “helpers” and organisms as “standalone” modules.
----
 
 Whereas _helpers_ can’t really exist on their own, _standalone_ modules can.
 

--- a/posts/2021-02-19-frontofthefrontend-and-backofthefrontend-web-development-by-brad-frost.md
+++ b/posts/2021-02-19-frontofthefrontend-and-backofthefrontend-web-development-by-brad-frost.md
@@ -10,7 +10,6 @@ linkTarget: "https://bradfrost.com/blog/post/front-of-the-front-end-and-back-of-
 > A front-of-the-front-end developer is a web developer who specializes in writing HTML, CSS, and presentational JavaScript code.
 
 > A back-of-the-front-end developer is a web developer who specializes in writing JavaScript code necessary to make a web application function properly.
----
 
 Brad also offers:
 

--- a/posts/2021-03-17-how-to-favicon-in-2021-on-csstricks.md
+++ b/posts/2021-03-17-how-to-favicon-in-2021-on-csstricks.md
@@ -8,7 +8,6 @@ linkTarget: "https://css-tricks.com/how-to-favicon-in-2021/"
 Some excellent favicon tips from Chris Coyier, referencing [Andrey Sitnik’s recent article](https://evilmartians.com/chronicles/how-to-favicon-in-2021-six-files-that-fit-most-needs) of the same name.
 
 > I always appreciate someone looking into and re-evaluating the best practices of something that literally every website needs and has a complex set of requirements.
----
 
 Chris is using:
 

--- a/posts/2021-03-19-in-praise-of-the-unambiguous-click-menu-on-csstricks.md
+++ b/posts/2021-03-19-in-praise-of-the-unambiguous-click-menu-on-csstricks.md
@@ -6,7 +6,6 @@ tags: [link, a11y, accessibility, hover, click, menu, navigation]
 linkTarget: "https://css-tricks.com/in-praise-of-the-unambiguous-click-menu/"
 ---
 Mark Root-Wiley explains why navigation menus that appear on click rather than hover are better.
----
 
 I like the fact that it calls out that:
 

--- a/posts/2021-03-22-encapsulated-eleventynunjucks-components-with-macros-by-trys-mudford.md
+++ b/posts/2021-03-22-encapsulated-eleventynunjucks-components-with-macros-by-trys-mudford.md
@@ -6,7 +6,6 @@ tags: [link, nunjucks, templatelanguages, javascript, jamstack]
 linkTarget: "https://www.trysmudford.com/blog/encapsulated-11ty-components/"
 ---
 Trys shows us how to use the Nunjucks `macro` to create encapsulated components. This works out less leaky and more predictable than an `include` preceded by variables assigned with `set`.
----
 
 Trys’s solution allows us to render components like so:
 

--- a/posts/2021-04-05-building-a-resilient-frontend-using-progressive-enhancement-service-manual-govuk.md
+++ b/posts/2021-04-05-building-a-resilient-frontend-using-progressive-enhancement-service-manual-govuk.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.gov.uk/service-manual/technology/using-progressive-enha
 GOV.UK’s guidance on developing using progressive enhancement is pretty great in all departments. It begins with this solid advice:
 
 > you should start by making your page work with just HTML, before adding anything else like Cascading Style Sheets (CSS) and JavaScript. This is because HTML is the most resilient layer. If the HTML fails there’s no web page. Should the CSS or JavaScript fail, the HTML will still render correctly.
----
 
 I particularly like the section where they address the misconception that a resilient baseline is only required in places where the user has explicitly disabled JavaScript and therefore not worth worrying about.
 

--- a/posts/2021-04-05-diffchecker-online-diff-tool-to-compare-text-to-find-the-difference-between-two-text-files.md
+++ b/posts/2021-04-05-diffchecker-online-diff-tool-to-compare-text-to-find-the-difference-between-two-text-files.md
@@ -6,6 +6,5 @@ tags: [link, tool, diff]
 linkTarget: "https://www.diffchecker.com/"
 ---
 > Diffchecker is a diff tool to compare text differences between two text files.
----
 
 I had cause to use this free diff tool recently to compare two large minified CSS files and it did the trick better than any others I’ve tried. Thumbs up!

--- a/posts/2021-04-09-designish-systems-by-ethan-marcotte.md
+++ b/posts/2021-04-09-designish-systems-by-ethan-marcotte.md
@@ -8,7 +8,6 @@ linkTarget: "https://ethanmarcotte.com/wrote/designish-systems/"
 Here’s an interesting new article from Ethan Marcotte, in which he muses on better ways to think about Design Systems based on his recent experience.
 
 > Once you’ve identified the root causes, you’ll be in a far, far better place to choose the right things — and, more importantly, to create a system that finally supports your design.
----
 
 Here’s what I took from it:
 

--- a/posts/2021-04-18-swipey-image-grids-on-cassiecodes.md
+++ b/posts/2021-04-18-swipey-image-grids-on-cassiecodes.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.cassie.codes/posts/swipey-image-grids/"
 A lovely post by Cassie Evans in which she demonstrates that SVG is not just for icons and illustrations. You might also reach for it to create a responsive, animated grid of images.
 
 > we have another grid at our disposal. SVG has its own internal coordinate system and it's responsive by design.
----
 
 There are lots of interesting techniques in here such as:
 

--- a/posts/2021-04-24-svg-crop.md
+++ b/posts/2021-04-24-svg-crop.md
@@ -9,6 +9,5 @@ Here’s a handy-looking tool for the SVG editing toolkit.
 
 > Remove blank space from around any SVG instantly.
 
----
 
 (via [@chriscoyier](https://twitter.com/chriscoyier))

--- a/posts/2021-05-02-changes-at-basecamp.md
+++ b/posts/2021-05-02-changes-at-basecamp.md
@@ -8,8 +8,7 @@ linkTarget: "https://world.hey.com/jason/changes-at-basecamp-7f32afc5"
 Basecamp—makers of project management, team communication and email software—have taken a controversial new stance against (amongst other things) political discussion at work, “paternalistic benefits” and 360 performance reviews.
 
 > These are difficult enough waters to navigate in life, but significantly more so at work. It's become too much. It's a major distraction. It saps our energy, and redirects our dialog towards dark places. It's not healthy, it hasn't served us well.
----
 
 On the surface I can see the appeal of “keeping it simple” in the modern workplace where so many different things vie for our attention. However the move to “silence conversation” feels out of step with a moment when—as a society—we’re trying hard to correct institutional, longstanding inequalities. Perhaps the channels where political/societal discourse can happen need better demarcated and the “house rules” properly set. But especially after the year we’ve just had it also feels wrong to take a dictatorial approach toward staff.
 
-It seems that [many departing employees feel the same way](https://techcrunch.com/2021/04/30/basecamp-employees-quit-ceo-letter/). 
+It seems that [many departing employees feel the same way](https://techcrunch.com/2021/04/30/basecamp-employees-quit-ceo-letter/).

--- a/posts/2021-05-11-one-web-component-to-rule-them-all-on-filament-group-inc.md
+++ b/posts/2021-05-11-one-web-component-to-rule-them-all-on-filament-group-inc.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.filamentgroup.com/lab/delegator/"
 Scott Jehl has taken a refreshingly Progressive Enhancement -centric look at Web Components.
 
 > this pattern provides a nice hook for adding progressive enhancements to already-meaningful HTML contained in these custom elements, leaving them resilient in the case of of script loading failures and allowing the page to start rendering before the JS happens to run.
----
 
 He goes further and creates a _factory_ for creating Web Components which allows adding to a single element many small behavioural script enhancements that may or may not relate to each other.
 

--- a/posts/2021-05-23-container-queries-in-web-components-or-max-bock.md
+++ b/posts/2021-05-23-container-queries-in-web-components-or-max-bock.md
@@ -8,7 +8,6 @@ linkTarget: "https://mxb.dev/blog/container-queries-web-components/"
 Max’s demo is really clever and features lots of interesting web component related techniques.
 
 > I came up with this demo of a book store. Each of the books is draggable and can be moved to one of three sections, with varying available space. Depending on where it is placed, different styles will be applied to the book.
----
 
 Some of the techniques I found interesting included:
 

--- a/posts/2021-05-24-dragula-browser-draganddrop-so-simple-it-hurts.md
+++ b/posts/2021-05-24-dragula-browser-draganddrop-so-simple-it-hurts.md
@@ -9,6 +9,5 @@ Hereâ€™s a nice, lightweight and framework-free drag and drop UI solution, thatâ
 
 > Drag and drop so simple it hurts
 
----
 
 (via [@mxbck](https://twitter.com/mxbck))

--- a/posts/2021-05-24-inspirejs.md
+++ b/posts/2021-05-24-inspirejs.md
@@ -8,6 +8,5 @@ linkTarget: "https://inspirejs.org/"
 > Lean, hackable, extensible slide deck framework
 
 I’ve been on the lookout for a lightweight, web standards based slide deck solution for a while and this one from Lea Verou could well be perfect.
----
 
 It has keyboard navigation, video and code demo support, an index page and much more… and it’s all powered by straightforward HTML, CSS and JavaScript. I need to give this a spin!

--- a/posts/2021-05-24-shifting-left-how-introducing-accessibility-earlier-helps-the-bbcs-design-system-or-by-sophie-beaumont-or-bbc-design-engineering.md
+++ b/posts/2021-05-24-shifting-left-how-introducing-accessibility-earlier-helps-the-bbcs-design-system-or-by-sophie-beaumont-or-bbc-design-engineering.md
@@ -9,7 +9,6 @@ Absolute gold here regarding accessibility, bloated components, and purpose vers
 
 > It’s easy for a component to become bloated and its purpose increasingly ambiguous.
 
----
 
 The article also makes a fundamental point.
 

--- a/posts/2021-06-18-inclusive-language-around-buttons.md
+++ b/posts/2021-06-18-inclusive-language-around-buttons.md
@@ -8,7 +8,6 @@ linkTarget: "https://twitter.com/Amy_Hupe/status/1405508276314333184"
 [@Amy_Hupe](https://twitter.com/Amy_Hupe) recently posed a great question on Twitter regarding inclusive language for buttons:
 
 > What's an inclusive way to describe what you do to a (digital) button, given it might be pressed with a mouse click, a screen tap, a key on a keyboard, and so on? I've tended to use "select" but wondering if that's right? 
----
 
 There are a lot of good suggestions and my current feeling is that:
 

--- a/posts/2021-06-19-clipboardjs-copy-to-clipboard-without-flash.md
+++ b/posts/2021-06-19-clipboardjs-copy-to-clipboard-without-flash.md
@@ -6,7 +6,6 @@ tags: [link, tool, web, development, copy, javascript]
 linkTarget: "https://clipboardjs.com/"
 ---
 Here’s a handy JS package for “copy to clipboard” functionality that’s lightweight and installable from npm.
----
 
 It also appears to have good legacy browser support plus a means for checking/confirming support too, which should assist if your approach is to only add a “copy” button to the DOM as a progressive enhancement.
 

--- a/posts/2021-06-25-astro.md
+++ b/posts/2021-06-25-astro.md
@@ -8,7 +8,6 @@ linkTarget: "https://astro.build/"
 Astro looks _very_ interesting. It’s in part a static site builder (a bit like [Eleventy](https://www.11ty.dev/)) but it also comes with a modern (revolutionary?) developer experience which lets you author components as web components or in a JS framework of your choice but then renders those to static HTML for optimal performance. Oh, and as far as I can tell theres no build pipeline!
 
 > Astro lets you use any framework you want (or none at all). And if most sites only have islands of interactivity, shouldn’t our tools optimize for that?
----
 
 People have been posting some great thoughts and insights on Astro already, for example:
 

--- a/posts/2022-07-13-avoiding-img-layout-shifts-aspectratio-vs-width-and-height-attributes-on-jake-archibalds-blog.md
+++ b/posts/2022-07-13-avoiding-img-layout-shifts-aspectratio-vs-width-and-height-attributes-on-jake-archibalds-blog.md
@@ -8,7 +8,6 @@ linkTarget: "https://jakearchibald.com/2022/img-aspect-ratio/"
 Recently I’ve noticed some developers recommending using the CSS `aspect-ratio` property directly on images. [My understanding of `aspect-ratio`](https://fuzzylogic.me/posts/2021-02-02-a-first-look-at-aspectratio-on-csstricks/) was that it’s not so much intended for elements like `img` which already have an intrinsic aspect ratio, but rather for the likes of `div` which do not. Furthermore, when the goal is to prevent the layout shift that can occur after an image loads we should supply our images with `width` and `height` HTML attributes rather than using CSS.
 
 In this timely post, Jake helpfully explains how `width` and `height` attributes are used by CSS as _presentation hints_ to automatically set an `aspect-ratio` that will also, in cases where the attributes were set wrongly, fall back to the image’s intrinsic aspect ratio. Therefore, concentrating on HTML alone is ideal for our _content_ images. My previous approach seems sound but I now know a little more about _why_.
----
 
 > If I'm adding an image to an article on my blog, that's content. I want the reserved space to be the aspect ratio of the content. If I get the width and height attributes wrong, I'd rather the correct values were used from the content image. Therefore, width and height attributes feel like the best fit. This means I can just author content, I don't need to dip into inline styles. 
 

--- a/posts/2022-07-13-dummy-post-title.md
+++ b/posts/2022-07-13-dummy-post-title.md
@@ -7,6 +7,5 @@ linkTarget: "https://dummy1.com/"
 draft: true
 ---
 Dummy excerpt
----
 
 Dummy body (via somebody)

--- a/posts/2022-07-15-perceived-affordances-and-the-functionality-mismatch-by-leonie-watson.md
+++ b/posts/2022-07-15-perceived-affordances-and-the-functionality-mismatch-by-leonie-watson.md
@@ -8,7 +8,6 @@ linkTarget: "https://tink.uk/perceived-affordances-and-the-functionality-mismatc
 Léonie tackles the prickly subject of “element re-purposing” in web development. This post follows a [fantastic Twitter exchange started by Lea Verou](https://twitter.com/LeaVerou/status/1545712667515654144) regarding whether the common visual design request for “adjacent but mututally exclusive buttons” should be built as radio buttons or using `<button>` elements.
 
 > Using one element or set of elements (usually because of their functionality) and styling them to look like something else is a common pattern […but…] it creates a mismatch between the actions people expect they can take and the ones they actually can.
----
 
 Relatedly, [Lea](https://twitter.com/LeaVerou) has also gathered her post-discussion thoughts and decisions into a blog post [What is the best way to mark up an exclusive button group?](https://lea.verou.me/2022/07/button-group/) _and_ shared a new [`button-group` web component](https://github.com/LeaVerou/nudeforms/tree/main/button-group)!
 

--- a/posts/2022-07-24-simple-inputtyperange-styling-by-ana-tudor.md
+++ b/posts/2022-07-24-simple-inputtyperange-styling-by-ana-tudor.md
@@ -6,7 +6,6 @@ tags: [link, codepen, forms, input, range, slider, a11y]
 linkTarget: "https://codepen.io/thebabydino/pen/XWEMgqY"
 ---
 Ana demonstrates how to achieve a range slider effect accessibly, using web standards and without needing to reach for libraries.
----
 
 As [Ana’s tweet explains](https://twitter.com/anatudor/status/1549284325765554176), this offers a number of features and benefits:
 

--- a/posts/2022-08-08-has-the-family-selector-chrome-developers-blog.md
+++ b/posts/2022-08-08-has-the-family-selector-chrome-developers-blog.md
@@ -6,6 +6,5 @@ tags: [link, css, selector, has, parent]
 linkTarget: "https://developer.chrome.com/blog/has-m105/"
 ---
 > The :has() CSS pseudo-class represents an element if any of the selectors passed as parameters match at least one element. But, it's more than a "parent" selector. That's a nice way to market it. The not so appealing way might be the "conditional environment" selector. But that doesn't have quite the same ring to it. How about the “family” selector?
----
 
 The CSS :has() pseudo-class is a game-changer and can do more than act as a parent selector, as Jhey illustrates.

--- a/posts/2022-08-08-these-3-pro-tips-saved-my-backhand-from-table-tennis-daily-on-youtube.md
+++ b/posts/2022-08-08-these-3-pro-tips-saved-my-backhand-from-table-tennis-daily-on-youtube.md
@@ -6,6 +6,5 @@ tags: [link, tabletennis, backhand, technique]
 linkTarget: "https://www.youtube.com/watch?v=28eNy4mtzKA"
 ---
 > In this video we go over the 3 pro tips from Liam Pitchford that helped transform Dan’s backhand!
----
 
 My backhand is kinda shaky at the moment and I struggle with correct elbow and wrist position so this tutorial video is timely and helpful.

--- a/posts/2022-08-25-use-css-has-to-set-rootlevel-styles-based-on-a-button-state.md
+++ b/posts/2022-08-25-use-css-has-to-set-rootlevel-styles-based-on-a-button-state.md
@@ -16,7 +16,6 @@ Great tip here from Jhey. He advises using a `button` with ARIA and a little Jav
 ```
 
 </figure>
----
 
 Seriously clever stuff! 
 

--- a/posts/2022-09-12-building-the-main-navigation-for-a-website-on-webdev.md
+++ b/posts/2022-09-12-building-the-main-navigation-for-a-website-on-webdev.md
@@ -6,7 +6,6 @@ tags: [link, a11y, aria, disclosure, navigation]
 linkTarget: "https://web.dev/website-navigation/"
 ---
 > learn about semantic HTML, accessibility, and how using ARIA attributes can sometimes do more harm than good.
----
 
 Alongside all the sound accessibility and hiding-related advice, I also found Manuel’s approach to progressive enhancement interesting. Rather than i) include a hamburger `button` directly in the DOM and set its initial state to `hidden`; or ii) create the `button` element with JavaScript, he instead nests the `button` in a [template](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/template) element then clones that element with JavaScript. He later [tweeted his rationale for this approach](https://twitter.com/mmatuzo/status/1568149800209498113):
 

--- a/posts/2022-10-02-better-accessible-names-or-hiddeblog.md
+++ b/posts/2022-10-02-better-accessible-names-or-hiddeblog.md
@@ -8,7 +8,6 @@ linkTarget: "https://hidde.blog/better-accessible-names/"
 Accessible names are used by assistive technologies to refer to elements on a web page. Hidde tells us how to word them so that they are more useful.
 
 > Because of how we use accessible names, we want to keep them functional and avoid naming controls after what they look like. Ideally, you do this in the imperative form, that makes it easiest to quickly grasp what a thing is going to do.
----
 
 My summary of Hidde’s top tips is:
 

--- a/posts/2022-10-19-accessibility-drives-aesthetics-paying-homage-to-oxo-eames-govuk-or-by-alex-chen-on-ux-collective.md
+++ b/posts/2022-10-19-accessibility-drives-aesthetics-paying-homage-to-oxo-eames-govuk-or-by-alex-chen-on-ux-collective.md
@@ -9,6 +9,5 @@ This article is a couple of years old but just popped up on my radar again. UX D
 
 > The article claims that if we are “too accessible” we will meet the needs of the minority but end up hurting those of the majority. This creates a false equivalence between having legitimate access needs and having a preference for a certain aesthetic.
 
----
 
 Alex goes on to praise examples where accessibility is used to drive aesthetics – such as the Eames leg splint and GOV.UK’s design system – as opposed to considering the two ideals opposites or that one needs sacrificed for the other.

--- a/posts/2022-10-23-lets-talk-about-web-components-or-brad-frost.md
+++ b/posts/2022-10-23-lets-talk-about-web-components-or-brad-frost.md
@@ -8,6 +8,5 @@ linkTarget: "https://bradfrost.com/blog/post/lets-talk-about-web-components/"
 Brad breaks down the good, bad and ugly of web components but also makes a compelling argument that we should get behind this technology.
 
 > I come from the Zeldman school of web standards, am a strong proponent of progressive enhancement, care deeply about accessibility, and want to do my part to make sure that the web lives up to its ideals. And I bet you feel similar. It’s in that spirit that I want to see web components succeed. Because web components are a part of the web!
----
 
 I’m with you, Brad. I just need to find practical ways to make them work.

--- a/posts/2022-11-02-choosing-a-date-we-want-to-know-your-use-cases-a-discussion-re-govuk-design-system.md
+++ b/posts/2022-11-02-choosing-a-date-we-want-to-know-your-use-cases-a-discussion-re-govuk-design-system.md
@@ -8,6 +8,5 @@ linkTarget: "https://github.com/alphagov/govuk-design-system/discussions/2375"
 > We want to find out if adding a 'date picker' component to the Design System is a good idea.
 
 > We're currently looking for: examples of date pickers in services: screenshots, prototypes, links to live services; use cases: explanations of why a 'date picker' was used in a service instead of a 'date input', or something else; research: how well 'date pickers' tested with users to complete different tasks.
----
 
 This discussion thread will be really helpful for everyone attempting to create an accessible Date Picker.

--- a/posts/2022-11-21-electronic-roots-01-the-story-of-axis-with-jeff-mills-by-openlab-radio-on-soundcloud.md
+++ b/posts/2022-11-21-electronic-roots-01-the-story-of-axis-with-jeff-mills-by-openlab-radio-on-soundcloud.md
@@ -6,6 +6,5 @@ tags: [link, techno, detroit, axis, music, culture]
 linkTarget: "https://soundcloud.com/openlabradio/electronic-roots-jeff-mills-on-the-story-of-axis-past-present-future"
 ---
 Loved this thoughtful and insightful interview with Jeff Mills by [Marcus Barnes](https://twitter.com/mgoldenbarnes).
----
 
 Among the highlights were Jeff’s thoughts on whether his music could viably still be described as “Detroit” given how long he’s lived away from the motor city, and also his reflections on the impact on his peer group of the 1980 film [American Gigolo](https://www.imdb.com/title/tt0080365/).

--- a/posts/2022-11-24-a-long-time-coming-on-the-absolutelee-podcast.md
+++ b/posts/2022-11-24-a-long-time-coming-on-the-absolutelee-podcast.md
@@ -6,7 +6,6 @@ tags: [link, podcast, video, racism, antisemitism, allyship]
 linkTarget: "https://www.absolutelee.co.uk/podcast-episodes/a-long-time-coming"
 ---
 > At the height of my playing career, David Baddiel wore blackface and put a pineapple on his head to mock me on national television every Friday night. While the chants have remained ever present, and David’s name has become synonymous with mine, it’s taken 25 years for us to finally meet face-to-face. In this episode, I talk with David about the impact his racist sketches had on me, my family and the wider community, and why allyship needs to become a bigger part of football.
----
 
 While watching David Baddiel's excellent [Jews Don't Count](https://www.channel4.com/programmes/david-baddiel-jews-dont-count) documentary on Channel Four I was intrigued by the section in which he spoke to Jason Lee, leading me to seek out this podcast episode.
 

--- a/posts/2022-11-24-the-anatomy-of-visuallyhidden-tpgi.md
+++ b/posts/2022-11-24-the-anatomy-of-visuallyhidden-tpgi.md
@@ -6,7 +6,6 @@ tags: [link, a11y, hiding, css]
 linkTarget: "https://www.tpgi.com/the-anatomy-of-visually-hidden/"
 ---
 > This article is not about when or why you would use visually-hidden content. There’s a number of excellent articles that discuss these questions in detail, notably Scott O’Hara’s Inclusively Hidden. But most of them don’t go into much detail about the specific CSS involved — why do we use this particular pattern, with these specific properties? So today I’m going to dissect it, looking at each of the properties in turn, why it’s there, and why it isn’t something else.
----
 
 Relevant to [How to hide elements on a web page](https://fuzzylogic.me/posts/how-to-hide-elements-for-different-browsing-contexts/).
 

--- a/posts/2022-11-25-new-css-for-styling-underlines-on-the-web-youtube.md
+++ b/posts/2022-11-25-new-css-for-styling-underlines-on-the-web-youtube.md
@@ -6,7 +6,6 @@ tags: [link, underline, css, video]
 linkTarget: "https://www.youtube.com/watch?v=sZS-7RX_c7g"
 ---
 We have new properties in CSS for styling underlines, as explained here by Jen Simmons.
----
 
 The relevant properties are:
 

--- a/posts/2022-11-26-bleep-mix-221-datassette-bleep-your-source-for-independent-and-innovative-music-buy-vinyl-and-cd-download-mp3-wavflac-24bit-wav-and-buy-merchandise.md
+++ b/posts/2022-11-26-bleep-mix-221-datassette-bleep-your-source-for-independent-and-innovative-music-buy-vinyl-and-cd-download-mp3-wavflac-24bit-wav-and-buy-merchandise.md
@@ -8,6 +8,5 @@ linkTarget: "https://bleep.com/features/bleep-mix-221-Datassette"
 Great DJ mix by one of my favourite electronic producers, Datassette.
 
 > This mix is all about that 160bpm+ energy that first inspired me to make music. Around 1996 — to me at least, with the advantages of teenage naîvety — it seemed like electronic music had burst into a whole new tempo range, where there were no rules and anything was possible - as long as it BELTS (which is still true). If you go beyond 200 BPM, you reach that zone where 16th notes start to dissolve into 32nds and your brain latches onto a whole new outer layer of rhythm, like a fractal or temporal shepard tone. There is still much to be discovered!
----
 
 I listened to this one while walking through the Glasgow Necropolis during one of those eerily-quiet Covid-era days, and it provided a welcome shock to the system.

--- a/posts/2022-11-27-getting-started-with-utopia-figma-plugins-utopia-blog.md
+++ b/posts/2022-11-27-getting-started-with-utopia-figma-plugins-utopia-blog.md
@@ -8,7 +8,6 @@ linkTarget: "https://utopia.fyi/blog/get-started-with-utopia-figma-plugins/"
 Here’s another tool from the Utopia creators to assist with breakpoint-free fluid responsive design.
 
 > Until now, the tooling for Utopia has been predominantly developer-focused, but we know that's only half the story. To start to address this, we've created a pair of Figma plugins to help designers set out Utopian project foundations.
----
 
 I also really like the idea of having three sets of type styles at both defined viewport sizes.
 

--- a/posts/2022-11-27-how-to-set-up-your-technics-1200-turntable-by-longbox-media-on-youtube.md
+++ b/posts/2022-11-27-how-to-set-up-your-technics-1200-turntable-by-longbox-media-on-youtube.md
@@ -6,6 +6,5 @@ tags: [link, technics, sl1210, howto, djing]
 linkTarget: "https://www.youtube.com/watch?v=-zo72dQV5F0"
 ---
 The best SL-1200/10 set-up video I’ve seen.
----
 
 I especially like the section on testing for channel imbalance by playing a mono record (such as [Nat Birchall's Upright Living LP](https://www.discogs.com/release/15752593-Nat-Birchall-meets-Al-Breadwinner-Upright-Living) and comparing the output meter for any differences between left and right, then untightening the relevant tonearm screws in order to make adjustments.

--- a/posts/2023-08-23-a-blog-post-which-uses-every-html-element-by-patrick-weaver.md
+++ b/posts/2023-08-23-a-blog-post-which-uses-every-html-element-by-patrick-weaver.md
@@ -6,7 +6,6 @@ tags: [link, html, web, a11y, development]
 linkTarget: https://www.patrickweaver.net/blog/a-blog-post-with-every-html-element/
 ---
 An interesting article which helps the author – and his readers – understand some of the lesser-used and more obscure HTML elements.
----
 
 While Patrick confesses he is still learning certain things and therefore I won’t regard his implementations as _gospel_ in the way I might an article by someone with greater HTML and accessibility expertise such as Adrian Roselli, I see this as another useful resource to help me when deciding whether or not an HTML choice is the semantic and or correct tool for a given situation.
 

--- a/posts/2023-08-23-progress-over-perfection-a-better-way-to-accessibility-merylnet.md
+++ b/posts/2023-08-23-progress-over-perfection-a-better-way-to-accessibility-merylnet.md
@@ -6,7 +6,6 @@ tags: [link, a11y, progress]
 linkTarget: "https://meryl.net/accessibility-progress-over-perfection/"
 ---
 This post from earlier this year offers a similar encouraging message to Henny Swan’s recent [_The only accessibility specialist in the room_](https://fuzzylogic.me/posts/the-only-accessibility-practitioner-in-the-room/). It contains advice that’s worth remembering when we have one of those ”what’s the point?’ moments! 
----
 
 Advice like:
 

--- a/posts/2023-08-23-shoelace-a-forwardthinking-library-of-web-components.md
+++ b/posts/2023-08-23-shoelace-a-forwardthinking-library-of-web-components.md
@@ -10,7 +10,6 @@ I’m interested by Shoelace’s MO as a collection of pre-rolled, customisable 
 I guess it’s a kind of Bootstrap for web components? I’m interested to see how well it’s done, how customisable the components are, and how useful it is in real life. Or if nothing else, I’m interested to see how they built their components!
 
 It’s definitely an interesting idea.
----
 
 I'll delve into Shoelace in more detail in the future when I have time, but in the meantime I was able to very quickly knock together [a codepen that renders a _Dropdown_ instance](https://codepen.io/fuzzylogicx/pen/rNoVJrQ).
 

--- a/posts/2023-08-24-3-questions-to-evaluate-design-patterns-and-avoid-unnecessary-work-that-degrades-ux-adam-silver-designer-london-uk.md
+++ b/posts/2023-08-24-3-questions-to-evaluate-design-patterns-and-avoid-unnecessary-work-that-degrades-ux-adam-silver-designer-london-uk.md
@@ -10,7 +10,6 @@ Adam offers tips for how to proceed when we are presented with a request for a s
 > The purpose of design is to solve actual problems. Not made up “I’m bored so I’ll come up with something new” problems.
 
 > So how can we evaluate these patterns, avoid unnecessary work and ultimately avoid patterns that degrade UX?
----
 
 He recommends we should start by asking three questions:
 

--- a/posts/2023-08-25-chris-packham-interview-in-the-guardian.md
+++ b/posts/2023-08-25-chris-packham-interview-in-the-guardian.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.theguardian.com/environment/2023/aug/19/chris-packham-a
 The naturalist, TV campaigner and activist on growing up, autism and asking himself “what is the best use of me?”.
 
 > He’s such a brilliant, sensitive soul, but it must be hard work being Chris Packham.
----
 
 Growing up I was never a fan of nature programmes like _The Really Wild Show_ so I didn’t pay Chris Packham too much attention. However in the last few years I've grown really fond of him. That's in part due to his revelations about his punky musical leanings and attitude, but more so due to his candid description of his autism, then his work to bring the true nature of autism and neruodivergency into the public eye and in doing so help others.
 

--- a/posts/5-things-i-learned-working-on-a-design-system-for-a-year-by-anda-popovici.md
+++ b/posts/5-things-i-learned-working-on-a-design-system-for-a-year-by-anda-popovici.md
@@ -22,6 +22,5 @@ draft: false
 
 ---
 I was delighted to discover that my talented colleague [Anda](https://www.andapopovici.com/) has her own website and uses it to write articles like this! This one is obviously pretty relevant to me too, given that I work on the same team.
----
 
 I particularly liked the fifth lesson – “You are an integral part of the company”. This is an aspect of Design System work that I care about because it’s important to me to work on impactful things that get into a lot of users’ hands.

--- a/posts/a-better-birthday-input-by-vitaly-friedman.md
+++ b/posts/a-better-birthday-input-by-vitaly-friedman.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 I recently signed up to Vitaly from Smashing Mag’s _Smart Interface Design Patterns_ newsletter. This latest edition regarding “date of birth” inputs was interesting, and well timed as my work colleagues and I are about to revisit our form patterns. It’s a nice explainer on why we should approach UI for dates the user _knows_ differently from UI for dates the user will _choose_.
----
 
 Vitaly recommends that when asking the user for a very specific date that they already know without needing to consult a calendar, drop-downs and calendar look-ups are unnecessary. And avoiding them is probably ideal, because `<input type=date>` and `<select>` based interfaces have some usability and accessibility kinks, as do many date-picker libraries.
 

--- a/posts/a-designer-s-guide-to-documenting-accessibility-user-interactions-by-stephanie-walter.md
+++ b/posts/a-designer-s-guide-to-documenting-accessibility-user-interactions-by-stephanie-walter.md
@@ -9,7 +9,6 @@ draft: false
 
 ---
 My teammate Colin just shared this brilliant designers’ guide to documenting accessibility and user interactions. It’s really thorough and includes some pretty clever annotation techniques.
----
 
 I agree with Stephanie that unless you ask the questions and document the answers regarding how a design will translate to an accessible reality then it can fall short at lots of points from the start to the implementation. This called to mind a similar perspective from Sophie Beaumont on [how the BBC shift left regarding accessibility](https://fuzzylogic.me/posts/2021-05-24-shifting-left-how-introducing-accessibility-earlier-helps-the-bbcs-design-system-or-by-sophie-beaumont-or-bbc-design-engineering/). 
 

--- a/posts/a-front-end-developer-s-job.md
+++ b/posts/a-front-end-developer-s-job.md
@@ -25,7 +25,6 @@ Meanwhile there’s another image of front-end development that’s very enginee
 
 I’m conscious of [the great divide](https://css-tricks.com/the-great-divide/) and while my career has straddled that divide, I’ll freely admit that at heart I’m [a front of the front-ender](https://bradfrost.com/blog/post/front-of-the-front-end-and-back-of-the-front-end-web-development/).
 
----
 
 Here’s a description of a “Design System engineer” that I recently compiled during while my team were recruiting for a software engineer:
 

--- a/posts/a-global-design-system.md
+++ b/posts/a-global-design-system.md
@@ -15,6 +15,5 @@ Hard to argue with Brad’s logic.
 > Our efforts to reduce duplicative work at the individual level are resulting in duplicative work at the inter-organization level.
 
 > A Global Design System would improve the quality and accessibility of the world’s web experiences, save the world’s web designers and developers millions of hours, and make better use of our collective human potential.
----
 
 > A Global Design System would exist as a standalone library of components that consumers would pull into their projects, style to match their brand/visual language, and integrate into their application’s business logic. Not only would this be far more efficient than having to design, build, test, deploy, and integrate bespoke components from scratch, a Global Design System would give teams added confidence that the components are sturdy and reliable.

--- a/posts/a-local-s-guide-to-on-the-guardian.md
+++ b/posts/a-local-s-guide-to-on-the-guardian.md
@@ -21,6 +21,5 @@ draft: false
 
 ---
 For a while now I’ve been enjoying this series of bite-sized travel guides from The Guardian, which puts the spotlight on a European town or city and hands over to a switched-on local to share food, shopping, cultural and green space highlights.
----
 
 Some are more suited to my tastes and budget than others, but overall they’ve been good. And not just for far-flung places – on a recent day-trip east I checked out a number of the stops on [their Edinburgh guide](https://www.theguardian.com/travel/2021/dec/19/locals-guide-to-edinburgh-bookshops-restaurants-parks-cocktail-bars) and it gave me a great basis for further exploration.

--- a/posts/a-visit-from-the-goon-squad-by-jennifer-egan.md
+++ b/posts/a-visit-from-the-goon-squad-by-jennifer-egan.md
@@ -9,7 +9,6 @@ mainImage:
   figcaption: A Visit from the Goon Squad
 ---
 I really enjoyed this book, recommended to me by [Gillian](https://twitter.com/Gilco80) and [Tom](https://twitter.com/mrtomchurchill).
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/accessibility-audits-of-varying-degrees.md
+++ b/posts/accessibility-audits-of-varying-degrees.md
@@ -20,7 +20,6 @@ draft: true
 When it comes to checking the accessibility of web pages and interfaces, there are varying approaches. 
 
 At the serious, professional end of the spectrum you enlist professional accessibility testers and they’ll conduct a proper audit with feedback closely linked to WCAG criteria and issue severities graded from low to critical. I’ve commissioned this kind of review before, and the results are always fantastic. 
----
 
 Low-hanging fruit audit
   [JK prev](https://fuzzylogic.me/posts/accessibility-testing-on-adactio.com/) 

--- a/posts/accessibility-personas.md
+++ b/posts/accessibility-personas.md
@@ -18,9 +18,8 @@ mainImage.isAnchor: false
 draft: false
 
 ---
-This interesting website from the GDS accessibility team sets out seven personas, each with different access needs. 
+This interesting website from the GDS accessibility team sets out seven personas, each with different access needs.
 
 > You can use these profiles to experience the web from the perspective of the personas and gain more understanding of accessibility issues.
----
 
 The site explains how to set up a device or browser to give each persona its own profile simulating the persona’s condition(s) and runs the assistive technology they use to help them.

--- a/posts/accessibility-testing-on-adactio.com.md
+++ b/posts/accessibility-testing-on-adactio.com.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 In this journal entry, Jeremy Keith argues that when it comes to accessibility testing it’s not just about finding issues—it’s about finding the issues at the right time.
----
 
 Here’s my summary:
 

--- a/posts/accessible-color-generator.md
+++ b/posts/accessible-color-generator.md
@@ -24,6 +24,5 @@ draft: false
 
 ---
 There are many [colour contrast checking tools](https://fuzzylogic.me/tags/contrast/) but I like this one from Erik Kennedy (of [Learn UI Design](https://learnui.design/)) a lot.  It features an intuitive UI using simple, human language that mirrors the task I’m there to achieve, and it’s great that if your target colour doesn’t have sufficient contrast to meet accessibility guidelines it will intelligently suggest alternatives that do.
----
 
 I’m sure everyone has their favourite tools; I just find this one really quick to use!

--- a/posts/accessible-modal-dialogues-in-2019.md
+++ b/posts/accessible-modal-dialogues-in-2019.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 I [previously noted](https://fuzzylogic.me/posts/meet-the-new-dialog-element/) Keith J Grant’s article on the HTML `dialog` element which promised a native means of handling popups and modal dialogues. I’ve not yet used `dialog` in production, partly because of [spotty browser support](https://caniuse.com/#search=dialog) (although there is a polyfill) but also partly because—for reasons I couldn’t quite put my finger on after reading the spec—it just didn’t feel like the finished article.
----
 
 Fast forward to March 2019 and [Scott O’Hara has written an excellent piece](https://www.scottohara.me/blog/2019/03/05/open-dialog.html) describing why it’s still not ready. There are a combination of factors: lack of browser support, reliance on JavaScript; and multiple accessibility issues.
 

--- a/posts/accessible-scalable-icons.md
+++ b/posts/accessible-scalable-icons.md
@@ -11,7 +11,6 @@ tags:
   - a11y
 ---
 Here’s how I’d handle various common SVG icon scenarios with accessibility in mind.
----
 
 ## Just an icon 
 

--- a/posts/adam-silver-more-devs-that-care-about-good-design-than-designers.md
+++ b/posts/adam-silver-more-devs-that-care-about-good-design-than-designers.md
@@ -22,7 +22,6 @@ draft: false
 A spicy but somewhat relatable thought from Adam Silver:
 
 > UX observation: I think there might be more devs who care about good design than there are designers. By “good” I mean works for everyone (is accessible) rather than looks nice. What do you think?
----
 
 The ensuing conversation is pretty interesting. I particularly liked these contributions from [Martin Hoyer](https://twitter.com/martynhoyer):
 

--- a/posts/adapting-stimulus-usage-for-better-progressive-enhancement.md
+++ b/posts/adapting-stimulus-usage-for-better-progressive-enhancement.md
@@ -12,7 +12,6 @@ tags:
 A while back, [Jake Archibald tweeted](https://twitter.com/jaffathecake/status/1230388412806520833):
 
 > Don't render buttons on the server that require JS to work.
----
 
 The idea is that user interface elements which depend on JavaScript (such as buttons) should be rendered _on the client-side_, i.e. with JavaScript.
 

--- a/posts/add-new-button-taxonomy-of-solutions.md
+++ b/posts/add-new-button-taxonomy-of-solutions.md
@@ -10,7 +10,6 @@ tags:
   - mobile
 ---
 Collecting and categorising design patterns for the “Add new item” pattern, including their pros and cons.
----
 
 I received an excellent newsletter from Erik Kennedy on this subject and wanted to document his suggestions. 
 

--- a/posts/add-opacity-to-existing-color.md
+++ b/posts/add-opacity-to-existing-color.md
@@ -20,7 +20,6 @@ draft: false
 
 ---
 Applying opacity to an existing colour value is a pretty common design requirement, and here Chris presents five ways to achieve it.
----
 
 I’ll admit that the explosion of colour models is one aspect of CSS that leaves me dizzy, so this explanation framed around a practical requirement really helps. The main approaches presented by Chris are:
 

--- a/posts/april-2022-mixtape.md
+++ b/posts/april-2022-mixtape.md
@@ -28,7 +28,6 @@ draft: false
 
 ---
 I put together a fairly spacey and mellow selection of laidback electronic sounds with a little nod to summer.
----
 
 {% if app.environment == "production" %}
 

--- a/posts/async-await.md
+++ b/posts/async-await.md
@@ -5,7 +5,6 @@ description: A more elegant way of handling promises
 tags: [development, javascript, asynchronous]
 ---
 My notes and reminders for handling promises with `async` and `await` In Real Life.
----
 
 As I see it, the idea is to switch to using `await` when working with promise-returning, asynchronous operations (such as `fetch`) because it lends itself to more flexible and readable code.
 

--- a/posts/atomic-design-by-brad-frost.md
+++ b/posts/atomic-design-by-brad-frost.md
@@ -6,6 +6,5 @@ date: 2018-09-12
 linkTarget: http://atomicdesign.bradfrost.com/
 ---
 The original call-to-arms and manual for Design Systems.
----
 
 Brad Frost explains why Design Systems are necessary, provides a methodology for Pattern Library creation, discusses Design System benefits and offers strategies for maintenance.

--- a/posts/autumn-2020-music-purchases.md
+++ b/posts/autumn-2020-music-purchases.md
@@ -19,7 +19,6 @@ mainImage:
 openGraphImage: "https://res.cloudinary.com/fuzzylogic/image/upload/q_auto,f_auto,w_1200/v1609971455/facefacts_1300_qzkqwh.jpg"
 ---
 
----
 <figure>
 <img
   eleventy:ignore

--- a/posts/back-to-top-with-modern-css.md
+++ b/posts/back-to-top-with-modern-css.md
@@ -9,7 +9,6 @@ tags:
 linkTarget: https://codepen.io/daviddarnes/pen/JjxmLpb?editors=0100
 ---
 David cleverly uses CSS alone (and only a few lines) to show a “back to top” link only after the user has started scrolling, then pin its position to the bottom-left of the screen.
----
 
 The clever `margin-top: 110vh` combined with `position: sticky` – since `110vh` is slightly more than 100% of the page’s height – gives the link a _starting position_ that is not initially visible but becomes visible once the user starts scrolling. The `bottom: 0` then ensures that when the user continues scrolling vertically the link “sticks” to the bottom-left of the page.
 

--- a/posts/backhand-topspin-attack-amateur-vs-pro-tom-lodziak-on-youtube.md
+++ b/posts/backhand-topspin-attack-amateur-vs-pro-tom-lodziak-on-youtube.md
@@ -13,7 +13,6 @@ draft: false
 
 ---
 Here’s a lovely slow-mo comparison of Liam Pitchford’s backhand technique versus that of an amateur.
----
 
 The main things I take from it are:
 

--- a/posts/badbadnotgood-at-qmu-glasgow.md
+++ b/posts/badbadnotgood-at-qmu-glasgow.md
@@ -20,7 +20,6 @@ mainImage.isAnchor: false
 draft: false
 ---
 Went to see BadBadNotGood with Marty, Jenni and Zippy last night, and they were fantastic. 
----
 
 We braved -7° conditions to meet at Tennent’s Bar on Byres Rd where we watched Argentia beat Croatia in the World Cup semi-final. Then onto the QMU, which provided a real nostalgia hit – I think the last time we were there was to see Roni Size and Reprazent in the _Brown Paper Bag_ era. 
 

--- a/posts/basic_entry.md
+++ b/posts/basic_entry.md
@@ -8,6 +8,5 @@ tags:
 draft: true
 ---
 Foo
----
 
 Bar

--- a/posts/better-alt-text.md
+++ b/posts/better-alt-text.md
@@ -15,7 +15,6 @@ As most of us know, the HTML `alt` attribute is for providing “alternate text�
 
 The article made some interesting points and even though I’ve been using the `alt` attribute for years I found three common cases where I could improve how I do things.
 
----
 
 ## Avoid starting with “photo of…”
 

--- a/posts/beyond-automatic-testing-matuzo.md
+++ b/posts/beyond-automatic-testing-matuzo.md
@@ -10,6 +10,5 @@ tags:
 linkTarget: https://www.matuzo.at/blog/beyond-automatic-accessibility-testing-6-things-i-check-on-every-website-i-build/
 ---
 Six accessibility tests Viennese Front-end Developer Manuel Matusovic runs on every website he develops, beyond simply running a Lighthouse audit.
----
 
 Includes “Test in Grayscale Mode” and “Test with no mouse to check tabbing and focus styles”. 

--- a/posts/big-list-of-http-static-server-one-liners.md
+++ b/posts/big-list-of-http-static-server-one-liners.md
@@ -11,6 +11,5 @@ draft: false
 
 ---
 Lots of different options for running a local web server. Choose from npx, ruby, python and many more.
----
 
 I also like Ritwick Dey’s [Live Server extension for VS Code](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer).

--- a/posts/block-links-a-tricky-ui-problem.md
+++ b/posts/block-links-a-tricky-ui-problem.md
@@ -5,7 +5,6 @@ description: "A problem to solve or just a bad idea?"
 tags: [development, design, links, buttons, a11y]
 ---
 You have a “card” component which includes a heading, some text, an image, and a link to the full article, and it’s working great. Then along comes a UX requirement that the _full card_ (not just the button or link) should be clickable. This is where things get complicated.
----
 
 ## TL;DR
 

--- a/posts/blockquotes-in-screen-readers.md
+++ b/posts/blockquotes-in-screen-readers.md
@@ -13,7 +13,6 @@ linkTarget: https://adrianroselli.com/2023/07/blockquotes-in-screen-readers.html
 
 ---
 Adrian tests how blockquotes, marked up in a variety of ways, are announced in different screen readers. 
----
 
 He concludes that his personal choice is as follows:
 
@@ -27,7 +26,6 @@ He concludes that his personal choice is as follows:
   <!-- other content -->
 </main>
 ```
----
 
 He avoids the `cite` _attribute_ completely because it creates noise in JAWS, and recommends against using `figure` with `figcaption` because it results in unnecessarily verbose and duplicate announcements.
 

--- a/posts/bram-stein-s-personal-website.md
+++ b/posts/bram-stein-s-personal-website.md
@@ -22,6 +22,5 @@ draft: false
 
 ---
 Bram Stein, a software architect at Adobe, [wrote the book on Webfonts](https://abookapart.com/products/webfont-handbook), so it’s no surprise that his own website showcases some pretty beautiful typography.
----
 
 Type is set in Expo Serif Pro, Expo Sans Pro and Source Code Pro.

--- a/posts/broken-copy-on-a11y-101.com.md
+++ b/posts/broken-copy-on-a11y-101.com.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 Here’s an accessibility tip that’s new to me. When the content of a heading, anchor, or other semantic HTML element contains smaller “chunks” of `span` and `em` (etc), the _VoiceOver_ screen reader on Mac and iOS annoyingly fails to announce the content as a single phrase and instead repeats the parent element’s role for each inner element. We can fix that by adding an inner “wrapper” element inside our parent and giving it `role=text`.
----
 
 Make sure not to add this role directly to your parent element since it will override its original role causing it to lose its intended semantics.
 

--- a/posts/brothy_chicken_thigh_soup_recipe.md
+++ b/posts/brothy_chicken_thigh_soup_recipe.md
@@ -12,7 +12,6 @@ noteWithTitle: true
 draft: false
 ---
 A tasty and healthy asian-style recipe from Gousto, which I enjoyed cooking and eating and would like to make again.
----
 
 ## Ingredients (for two people)
 

--- a/posts/browser-support-heuristics.md
+++ b/posts/browser-support-heuristics.md
@@ -17,7 +17,6 @@ tags:
 draft: false
 ---
 In web development it’s useful when we can say “if the browser supports X, then we know it also supports Y”.
----
 
 There was a small lightbulb moment at work earlier this year when we worked out that:
 

--- a/posts/building-a-toast-component-by-adam-argyle.md
+++ b/posts/building-a-toast-component-by-adam-argyle.md
@@ -26,7 +26,6 @@ draft: false
 Great tutorial (with accompanying video) from Adam Argyle which starts with a useful definition of what a `Toast` is and is not:
 
 > Toasts are non-interactive, passive, and asynchronous short messages for users. Generally they are used as an interface feedback pattern for informing the user about the results of an action. Toasts are unlike notifications, alerts and prompts because they're not interactive; they're not meant to be dismissed or persist. Notifications are for more important information, synchronous messaging that requires interaction, or system level messages (as opposed to page level). Toasts are more passive than other notice strategies.
----
 
 There are some important distinctions between toasts and notifications in that definition: toasts are for less important information and are non-interactive. I remember in a previous work planning exercise regarding a toast component a few of us got temporarily bogged down in working out the best JavaScript templating solution for SVG icon-based “Dismiss” buttons… however we were probably barking up the wrong tree with the idea that toasts should be manually dismissable.
 

--- a/posts/bulb-solar-design-system.md
+++ b/posts/bulb-solar-design-system.md
@@ -9,5 +9,4 @@ tags:
 linkTarget: https://design.bulb.co.uk/
 ---
 > It’s a collection of shared patterns and practices that allow our team to build quality user interfaces consistently and quickly.
----
 

--- a/posts/buttons-versus-links-differences-and-tips.md
+++ b/posts/buttons-versus-links-differences-and-tips.md
@@ -28,7 +28,6 @@ draft: false
 
 ---
 On the web buttons and links are fundamentally different materials. However some design and development practices have led to them becoming conceptually “bundled together” and misunderstood. Practitioners can fall into the trap of seeing the surface-level commonality that “you click the thing, then something happens” and mistakenly thinking the two elements are interchangeable. Some might even consider them as a single “button component” without considering the distinctions underneath. However this mentality causes our users problems _and_ is harmful for effective web development. In this post I’ll address why buttons and links are different and exist separately, and when to use each.
----
 
 ## Problematic patterns
 

--- a/posts/buying-logging-and-recommending-books.md
+++ b/posts/buying-logging-and-recommending-books.md
@@ -14,7 +14,6 @@ tags:
 draft: false
 ---
 I currently buy books from a mix of physical and online stores including Waterstones, Hive, Blackwells and most recently, [The Outwith Agency](https://www.theoutwithagency.co.uk/) – my new local shop.
----
 
 I have a [Bookshelf](https://fuzzylogic.me/bookshelf/) section of my website which lists a number of books I’ve read, including what I’m currently reading. The idea was very much inspired by [Dave Rupert’s bookshelf](https://daverupert.com/bookshelf/).
 

--- a/posts/careers-talk-at-pollokshields-primary.md
+++ b/posts/careers-talk-at-pollokshields-primary.md
@@ -33,7 +33,6 @@ I also had my fears dispelled somewhat when I heard that although there’d be l
 I’m pleased to say it went well and generally gave me a warm glow. On reflection I think I prepared well, my nerves were manageable, and I communicated clearly. The kids were lovely and asked lots of questions! What characteristics do you need to be a good software engineer? Did my parents support my career choices? And so on.
 
 They also gave me a lovely certificate and a large Dairy Milk bar (something that’s always welcome in our house).
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/carrd.md
+++ b/posts/carrd.md
@@ -9,6 +9,5 @@ tags:
 linkTarget: https://carrd.co/
 ---
 These days when friends tell me they want a personal website, it’s often just a single-page profile that they’re really after rather than something pricier and more complicated.
----
 
 In the past there were services like [http://flavors.me/](http://flavors.me/) but it seems to have fallen by the wayside. This looks like a decent option to point friends toward if they’re not looking for a blog or want to take baby steps toward that. Incidentally, I came across Carrd through Chris Ferdinandi’s [Vanilla JS List](https://vanillajslist.com/) which features organisations which favour Vanilla JavaScript over JS frameworks.

--- a/posts/caught-up-in-this-big-rhythm.md
+++ b/posts/caught-up-in-this-big-rhythm.md
@@ -17,7 +17,6 @@ location: Glasgow
 ---
 I got home from Friday morning’s dog walk to find some records in the post. I’d recently deleted my Discogs wants-list having realised twenty years too late that it is far too addictive, and as a last hurrah had earmarked a last few key wants. One of those was The Blue Nile’s _Tinseltown in the rain_ – a slice of Scottish pop perfection on Linn records – and I enjoyed a brief listen before heading back out.
 
----
 
 First stop of the afternoon was a visit to Greater Govanhill’s office to collect their latest edition (more on this later).
 

--- a/posts/certbot-troubleshooting.md
+++ b/posts/certbot-troubleshooting.md
@@ -5,7 +5,6 @@ date: 2019-02-13
 tags: [web, development, ssl, secure, sslcert, certbot, vhosts, letsencrypt]
 ---
 When taking the DIY approach to building a new server, Certbot is a great option for installing secure certificates. However, sometimes you can run into problems. Here, I review the main recurring issues I’ve encountered and how I fixed them.
----
 
 When creating new servers for my projects I use [Certbot](https://certbot.eff.org/) as a means of installing free Let’s Encrypt secure certificates.
 

--- a/posts/check-localhost-development-on-your-iphone.md
+++ b/posts/check-localhost-development-on-your-iphone.md
@@ -19,6 +19,5 @@ draft: false
 
 ---
 Here’s how to check the application you’re running locally on your MacBook on your iPhone.
----
 
 It’s pretty much a case of connecting your iPhone to your MacBook by USB, tweaking some settings, then browsing to the application via a given IP in iOS Safari.

--- a/posts/choosing-between-online-services.md
+++ b/posts/choosing-between-online-services.md
@@ -19,7 +19,6 @@ tags:
 draft: false
 ---
 A [recent issue of the dConstruct newsletter](https://tinyletter.com/clearleft/letters/dconstruct-from-clearleft-musique-non-stop) about choosing more ethical online services really chimed with me at a time when I’ve been reflecting on my online habits.
----
 
 [Clearleft](https://clearleft.com/) produce an excellent regular technology-based newsletter – [dConstruct](https://tinyletter.com/clearleft) – to which I heartily recommend subscribing.
 

--- a/posts/codrops-css-reference.md
+++ b/posts/codrops-css-reference.md
@@ -19,7 +19,6 @@ draft: false
 
 ---
 Here’s a comprehensive and great-looking CSS reference featuring lots of examples.
----
 
 While these days I normally reach for [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS) to keep me right on any given CSS feature, I’ve been thinking that with the recent explosion of new CSS features and syntax it’d be great to do a refresher course by working my way through a structured list of features—just like I did with Eric Meyer’s [CSS: The Definitive Guide](https://meyerweb.com/eric/books/css-tdg/) back in the day—and Codrops’ reference could be the perfect place.
 

--- a/posts/collected-web-accessibility-guidelines-tips-and-tests.md
+++ b/posts/collected-web-accessibility-guidelines-tips-and-tests.md
@@ -22,7 +22,6 @@ Caveats and notes:
 1. this is a living document which I’ll expand over time; 
 2. I’m standing on the shoulders of real experts and I list my [references](#references) at the foot of the article; and
 3. if I’ve got anything wrong, please [let me know!](https://twitter.com/fuzzylogicx)
----
 
 ## Table of contents
 

--- a/posts/colors-a-nicer-color-palette-for-the-web.md
+++ b/posts/colors-a-nicer-color-palette-for-the-web.md
@@ -6,6 +6,5 @@ tags: [link, web, development, a11y, colour]
 linkTarget: http://clrs.cc/
 ---
 > Skinning your prototypes just got easier - colors.css is a collection of skin classes to use while prototyping in the browser.
----
 
 They also provide [ninety examples of “A11Y compliant color combos”](http://clrs.cc/a11y/) which is really handy.

--- a/posts/component-specifications.md
+++ b/posts/component-specifications.md
@@ -26,6 +26,5 @@ Nathan on how complex components require comprehensive specifications rather tha
 > I’m still amazed when designers schlep together a few pictures, publish a configurable Figma component, point their developer counterparts at the main component and say “Use Figma’s inspect tool.”
 
 > Things have changed. Components are more complicated. Designers are delivering to many different developers. Accessibility has risen to the fore. For design systems that scale, teams are finding it necessary to write down all the details again. 
----
 
 At work in our project to improve our component documentation across the component life-cycle, we’ve been following Nathan’s advice and using his plug-in to assist with the “specification” aspect.

--- a/posts/conditional-border-radius-in-css-by-ahmad-shadeed-via-css-tricks.md
+++ b/posts/conditional-border-radius-in-css-by-ahmad-shadeed-via-css-tricks.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 Here’s a “media query free” CSS one-liner which lets you set an element to have no border-radius when it is the full width of the viewport, but otherwise to have a border-radius.
----
 
 It uses the same 9999 multiplication technique as [Every Layout](https://every-layout.dev/) do to create a toggle.
 

--- a/posts/cookie-consent-by-osano-the-most-popular-solution-to-the-eu-cookie-law.md
+++ b/posts/cookie-consent-by-osano-the-most-popular-solution-to-the-eu-cookie-law.md
@@ -6,7 +6,6 @@ tags: [link, development, tool, cookies, legal]
 linkTarget: "https://www.osano.com/cookieconsent"
 ---
 The most popular drop-in solution to the EU Cookie Law requirements.
----
 
 Over the last year I’ve been successfully using Cookie Consent by Osano on a number of commercial websites. Essentially this is a banner which appears at the bottom (or top) of your website and asks the visitor to explicitly give (or decline to give) consent for the cookies your website uses. It’s a great free resource which handles the requisite GDPR requirements (and more) and offers a number of customisation options.
 

--- a/posts/crafting-component-api-together-by-nathan-curtis-on-medium.md
+++ b/posts/crafting-component-api-together-by-nathan-curtis-on-medium.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 Nathan (of [EightShapes](https://eightshapes.com/)) discusses how to unify anatomy and props across code and design tools.
----
 
 I love this article. It tackles some difficult, real problems that occur during the process of trying to align design and development but proposes interesting ways of mitigating them.
 

--- a/posts/css-pointer-events-to-the-rescue.md
+++ b/posts/css-pointer-events-to-the-rescue.md
@@ -5,9 +5,8 @@ description: When clicking or tapping your button or anchor doesn’t work, this
 tags: [entry, web, development, css, solution]
 ---
 Sometimes, for reasons unknown, we find that clicking or tapping an element just isn’t working. Here’s a CSS-based approach that might help.
----
 
-I’ve recently encountered the scenario – usually in reasonably complex user interfaces – where I have an anchor (or ocassionally, a button) on which clicks or taps just aren’t working, i.e. they don’t trigger the event I was expecting. 
+I’ve recently encountered the scenario – usually in reasonably complex user interfaces – where I have an anchor (or ocassionally, a button) on which clicks or taps just aren’t working, i.e. they don’t trigger the event I was expecting.
 
 On further investigation I found that this is often due to having an absolutely positioned element which is to some extent overlaying (or otherwise interfering with) our target clickable element. Alternatively, it may be because we needed a child/nested element inside our anchor or button and it is this element that the browser perceives as being the clicked or tapped element.
 

--- a/posts/custom-multi-checkbox-and-multi-radio-controls.md
+++ b/posts/custom-multi-checkbox-and-multi-radio-controls.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 Our Design System team has recently received “new component requests” for some custom filtering controls. These _look like_ custom-styled `<select>`s however their “options” appear more like checkboxes and radio buttons. I think the inspiration was [Carbon Design System’s Dropdown component](https://carbondesignsystem.com/components/dropdown/usage) and the idea is to bring consistency to filtering controls in forms. Although it’s not yet time to fully explore this and make a yay/nay decision on the request, I’ve been doing some initial thinking.
----
 
 (Note: this post is kinda a journey and work-in-progress. I’ll return to complete it and tidy up. For now it serves as a handy log of my research.)
 

--- a/posts/data-vis-smashing.md
+++ b/posts/data-vis-smashing.md
@@ -12,6 +12,5 @@ linkTarget: https://mailchi.mp/smashingmagazine.com/last-seats-smart-interface-d
 Here are a bunch of great tips and resources for creating charts and graphs, condensed into a 6-minute read.
 
 It’d be interesting to look at the key recommendations in this article and compare our web-based charts at work against them.
----
 
 My thanks to Vitaly and the Smashing team for this roundup.

--- a/posts/david-darnes-web-component-github-stater-template.md
+++ b/posts/david-darnes-web-component-github-stater-template.md
@@ -10,7 +10,6 @@ tags:
 linkTarget: https://darn.es/web-component-github-starter-template/
 ---
 David’s template provides not just the starter component code but also a nice readme, issue template, and publish-to-NPM flow.
----
 
 It’s also always interesting to see how different developers structure their web component JavaScript. David’s code includes a neat and interesting approach to registering the comoponent, and favours setup being written in the `connectedCallback()`.
 

--- a/posts/definitive-web-font-font-face-syntax.md
+++ b/posts/definitive-web-font-font-face-syntax.md
@@ -11,7 +11,6 @@ tags:
 draft: false
 ---
 These days, whenever I’m about to use a web font on a new site I generally find myself running a google search for the latest “definitive `@font-face` syntax” that covers all modern browser/device needs.
----
 
 For a long time I headed straight for [Paul Irish’s Bulletproof @font-face Syntax](https://www.paulirish.com/2009/bulletproof-font-face-implementation-syntax/) but I noted a few years back that he’d stopped updating it.
 

--- a/posts/design-engineering-on-the-clearleft-podcast.md
+++ b/posts/design-engineering-on-the-clearleft-podcast.md
@@ -25,6 +25,5 @@ draft: false
 
 ---
 Loved this short listen from Clearleft, on a subject close to my heart! New job titles can feel a bit “emperor’s new clothes” but with _Design Engineering_ I think Clearleft, GitHub et al. might be onto something. It was fascinating hearing people from both design and engineering backgrounds give their perspectives, and how ultimately they’re addressing the same thing—the need to “finesse the overlaps/gaps” between design and the realisation of that design in engineering, especially in light of the complexities of the modern front-end.
----
 
 (via [@Stugoo](https://twitter.com/stugoo))

--- a/posts/design-systems-should-avoid-god-components-and-swiss-army-knives.md
+++ b/posts/design-systems-should-avoid-god-components-and-swiss-army-knives.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 Something we often talk about in our Design System team is that components should not be like Swiss Army Knives. It’s better for them to be laser-focused because by limiting their scope to a single task they are more reusable and support a more extensible system through composition.
----
 
 Discussions often arise when we consider the flip-side – components which do too much, know too much, or care too much! When they cover too much ground or make assumptions about their context, things go wrong. Here are some examples.
 

--- a/posts/developer-considerations_relating_to_user_font_size_preferences.md
+++ b/posts/developer-considerations_relating_to_user_font_size_preferences.md
@@ -12,7 +12,6 @@ tags:
   - preferences
 ---
 As a front-end developer I’m called upon both to test that web pages support user font-size preferences, and to build pages which offer that support. Here are my notes on how to do both.
----
 
 ## Testing
 

--- a/posts/development_decisions.md
+++ b/posts/development_decisions.md
@@ -8,7 +8,6 @@ tags:
 - development
 ---
 Here are some recurring development decisions I make when maintaining my personal website/blog, with some accompanying rationale.
----
 
 ## Where should landmark-related HTML elements be in the source?
 

--- a/posts/different-approaches-to-writing-javascript-in-a-resilient-way.md
+++ b/posts/different-approaches-to-writing-javascript-in-a-resilient-way.md
@@ -12,7 +12,6 @@ tags:
 draft: true
 ---
 Lorem
----
 
 ## Prologue: a single JS error breaking all JS for your site
 

--- a/posts/displaying-tables-on-narrow-screens.md
+++ b/posts/displaying-tables-on-narrow-screens.md
@@ -16,7 +16,6 @@ draft: false
 
 ---
 Responsive design for tables is tricky. Sure, you can just make the table’s container horizontally scrollable but that’s more a developer convenience than a great user experience. And if you instead try to do something more clever, you can run into challenges [as I did in the past](https://fuzzylogic.me/posts/tables-and-pseudo-tables-lessons-and-tactics/). Still, we should strive to design good narrow screen user experiences for tables, alongside feasible technical solutions to achieve them.
----
 
 In terms of UI design, I was interested to read Erik Kennedy’s recent newsletter on [_The best way to display tables on mobile_](https://ckarchive.com/b/75u7h8hk4mne3). Erik lists three different approaches, which are (in reverse order of his preference):
 

--- a/posts/division-and-construction-in-design-systems.md
+++ b/posts/division-and-construction-in-design-systems.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 Over the last couple of days I’ve been watching [an interview with Brad Frost on Storybook’s channel](https://www.youtube.com/watch?v=jR0Gefa4lpg). I’m still only halfway through but it’s great so far.
----
 
 One part I’m loving is, from about 25 mins in, when Brad talks abut how [Atomic Design](https://bradfrost.com/blog/post/atomic-web-design/) _crucially_ includes the notion of not only “breaking interfaces down” (like every DS does) but also “building them back up”. It’s not just the atoms and molecules that are important, but also combining them into (in Atomic Design parlance) organisms and templates, too. For example when using Storybook as an internal workshop (in my team our equivalent is [LookBook](https://github.com/allmarkedup/lookbook)), he makes a point of it not just including components but also templates, so that:
 

--- a/posts/dj-mix-manifold.md
+++ b/posts/dj-mix-manifold.md
@@ -7,7 +7,6 @@ tags: [entry, music, mix, electro, techno, isonoe]
 First in a series of mainly short, off the cuff mixes where I just hit record and see where it goes. This one’s on the Electro tip, having kicked it off with Versalife’s _Manifold_ from last year.
 
 <iframe title="“07/01/21 DJ Mix – Manifold by Laurence Hughes" width="100%" height="120" src="https://www.mixcloud.com/widget/iframe/?hide_cover=1&feed=%2Flaurencehughes%2F7121-mix-manifold%2F" frameborder="0" ></iframe>
----
 
 ## Tracklist: 
 

--- a/posts/do-androids-dream-of-electric-sheep-by-phillip-k-dick.md
+++ b/posts/do-androids-dream-of-electric-sheep-by-phillip-k-dick.md
@@ -9,7 +9,6 @@ mainImage:
   figcaption: Do Androids Dream of Electric Sheep
 ---
 In my ongoing quest to catch up on books I should have read years ago, I recently finished reading “Do Androids Dream of Electric Sheep?” – the book on which _Bladerunner_ was based.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/do-i-need-to-care-about-ie-11.md
+++ b/posts/do-i-need-to-care-about-ie-11.md
@@ -12,7 +12,6 @@ tags:
 draft: true
 ---
 TL;DR: yes, but with a Minimum Viable Experience. 
----
 
 Microsoft are sunsetting IE 11 for xyz.
 

--- a/posts/docsify-–-a-magical-documentation-site-generator.md
+++ b/posts/docsify-–-a-magical-documentation-site-generator.md
@@ -12,6 +12,5 @@ draft: false
 ---
 > docsify generates your documentation website on the fly. Unlike GitBook, it does not generate static html files. Instead, it smartly loads and parses your Markdown files and displays them as a website.
 
----
 
 I just completed a training workshop where the course notes were provided in a website created using this software (and hosted on Netlify), and was really impressed.

--- a/posts/does-the-html-details-element-solve-progressively-enhanced-disclosures.md
+++ b/posts/does-the-html-details-element-solve-progressively-enhanced-disclosures.md
@@ -25,7 +25,6 @@ The HTML `details` element continues to gain fans and get developers’ juices f
 > I love the details/summary HTML elements. So versatile. My favorite part is being able to show a collapsed state from the start without worrying about potential operability issues if JavaScript fails to run (since its behavior doesn't need it).
 
 Scott goes on to describe how creating disclosure widgets (controls that hide and show stuff) with resilience in mind is so much more difficult when not using `<details>` since it can require complex progressive enhancement techniques. At the very least these involve making content available by default in case JavaScript fails, then hiding it when the disclosure widget script loads successfully, ideally without a jarring flash of content in between.
----
 
 Like Scott says, the `<details>` element is different because you can have the content collapsed (hidden) by default without worrying about JavaScript and workarounds since the hidden content can be toggled open natively. That‘s a real superpower… and also makes you wonder: how many different places and different ways might we use this super-element?
 

--- a/posts/dominos-lose-appeal-regarding-digital-accessibility.md
+++ b/posts/dominos-lose-appeal-regarding-digital-accessibility.md
@@ -9,6 +9,5 @@ tags:
 linkTarget: http://www.webaxe.org/supreme-court-favors-digital-accessibility-dominos-case/
 ---
 > Digital products which are a public accommodation must be accessible, or will be subject to a lawsuit (and probably lose).
----
 
 This US Supreme Court decision on October 7, 2019 represents a pretty favourable win for digital accessibility against a big fish that was trying to shirk its responsibilities.

--- a/posts/don-t-set-cursor-pointer-on-buttons.md
+++ b/posts/don-t-set-cursor-pointer-on-buttons.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 For many years I’ve been applying `cursor: pointer` to buttons because it felt right and would improve the user experience.
----
 
 [As Florens Verschelde explains](https://github.com/necolas/normalize.css/issues/371#issuecomment-60072171), that approach is probably best avoided. I was going against the W3C’s spec that `cursor: pointer` should be reserved for links, and was adding to the usability _antipattern_ where “everything resembles a link”.
 

--- a/posts/doppler-type-scale-with-dynamic-line-height.md
+++ b/posts/doppler-type-scale-with-dynamic-line-height.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 `line-height` on the web is a tricky thing, but this tool offers a clever solution.
----
 
 It’s relatively easy to set a sensible unit-less default ratio for body text (say `1.5`), but that tends to need tweaked and tested for headings (where spacious line-height doesn’t quite work; but tight line-height is nice until the heading wraps, etc). 
 

--- a/posts/dos-and-dont’s-of-changing-visual-order-with-css.md
+++ b/posts/dos-and-dont’s-of-changing-visual-order-with-css.md
@@ -17,7 +17,6 @@ tags:
 draft: false
 ---
 When considering using Flexbox or CSS Grid to change the visual order of elements, remember that “with great power comes great responsibility”.
----
 
 Flexbox and CSS Grid have given us new powers to shuffle the visual order of elements on a web page such that it is different to the element order in the source code.
 

--- a/posts/duet-design-system.md
+++ b/posts/duet-design-system.md
@@ -16,6 +16,5 @@ linkTarget: https://www.duetds.com/using-components/
 Here’s a lovely Design System that interestingly uses [Eleventy](https://www.11ty.dev/) for its reference website and other generated artefacts:
 
 > We use Eleventy for both the static documentation and the dynamically generated parts like component playgrounds and design tokens. We don’t currently use a JavaScript framework on the website, except Duet’s own components.
----
 
 I find Duet interesting both from the Design System perspective (it contains lots of interesting component techniques and options) but also in terms of how far 11ty can be pushed.

--- a/posts/editable-table-cells.md
+++ b/posts/editable-table-cells.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 Yesterday the Design System team received a tentative enquiry regarding making table cells editable. I’m not yet sure whether or not this is a good idea – experience and spidey sense tell me it’s not – but regardless I decided to start exploring so as to base my answer on facts and avoid being overly cautious.
----
 
 In my mind’s eye, there are two ways to achieve this:
 

--- a/posts/everybody-in-the-place.md
+++ b/posts/everybody-in-the-place.md
@@ -21,7 +21,6 @@ draft: false
 linkTarget: https://www.bbc.co.uk/programmes/m000777d
 ---
 Enjoyed this acid house history lesson from Jeremy Deller – especially some of the footage from the early Manchester scene which I hadn’t seen before.
----
 
 {% if app.environment == "production" %}
 

--- a/posts/ewan’s-celebration.md
+++ b/posts/ewan’s-celebration.md
@@ -11,8 +11,7 @@ tags:
   - techno
 ---
 Yesterday was the celebration of the life of Ewan (Ginny). It was a beautiful service held at The Hurlet crematorium then at No 10 Hotel.
----
 
 His was really a unique life and it was wonderful to hear from Sally and others about his family life, his time at university (we were at Strathclyde Uni at the same time), good times with friends, his love of music, his inspiring career, the way he handled his medical condition and more. I’ve also never heard music I love such as Carl Craig’s [A Wonderful Life](https://www.youtube.com/watch?v=oy5BKah2bf0) and Underground Resistance’s [Journey of the dragons](https://www.youtube.com/watch?v=BcQKVdEERkA) played in the context of a funeral and I found that aspect (and how Marty had thoughfully chosen those pieces) very moving.
 
-It really was a mixture of sad and happy. I hope Ruth was happy with how everything went – I think she was. A fitting send-off to a great person. 
+It really was a mixture of sad and happy. I hope Ruth was happy with how everything went – I think she was. A fitting send-off to a great person.

--- a/posts/favourite-eleventy-11ty-resources.md
+++ b/posts/favourite-eleventy-11ty-resources.md
@@ -14,7 +14,6 @@ draft: false
 
 ---
 Here are my current go-to resources when building a new site using Eleventy (11ty).
----
 
 [Build an Eleventy site from scratch](https://egghead.io/courses/build-an-eleventy-11ty-site-from-scratch-bfd3) by Stephanie Eckles. As the name suggests, this is for starting from a blank canvas. It includes a really simple and effective way of setting up a Sass watch-and-build pipeline that runs alongside that of Eleventy, using only `package.json` scripts rather than a bundler.
 

--- a/posts/features-of-my-personal-site.md
+++ b/posts/features-of-my-personal-site.md
@@ -14,7 +14,6 @@ Like all gardens, they can become a bit unruly and need some weeding. Right now,
 So, here’s a post in which I’ll log my website’s current features. This should be useful in and of itself as a stepping stone to writing a proper readme. However it’ll also help me reflect on my website’s health and maintainability so I can decide which features to nourish and which to prune.
 
 Note: this post will take a bit of time and a few sessions, so please regard it as a work in progress.
----
 
 ## What I want
 

--- a/posts/fixing-github-command-line-authentication-issues.md
+++ b/posts/fixing-github-command-line-authentication-issues.md
@@ -7,11 +7,10 @@ tags: [development, git, github, commandline, fix]
 On at least two ocassions I’ve found myself scratching my head when an attempted push to a newly-created Github repo is met with authentication failures, despite me being sure I’m using the correct credentials.
 
 Here’s the lowdown on the issue and how to resolve it.
----
 
 Essentially the problem relates to Github expecting a _personal access token_ rather than a password (although it provides no helpful hints that this is the case).
 
-This might be because your Github account has <abbr title="Two-Factor Authentication">2FA</abbr> enabled, and/or for security purposes because your account is part of an organisation that uses SAML single sign-on (SSO). 
+This might be because your Github account has <abbr title="Two-Factor Authentication">2FA</abbr> enabled, and/or for security purposes because your account is part of an organisation that uses SAML single sign-on (SSO).
 
 In my case, I had previously created a personal access token with the requisite privileges (in my Github account’s [Developer Settings > Tokens](https://github.com/settings/tokens) section) for the purposes of API access, so I was able to just reuse that. However, if need be I could have created a new one.
 

--- a/posts/flexible-tag-like-functionality-for-custom-keys-in-eleventy.md
+++ b/posts/flexible-tag-like-functionality-for-custom-keys-in-eleventy.md
@@ -9,7 +9,6 @@ tags:
   - solution
 ---
 I have an open-source, Eleventy-based project where the posts are restaurants, each of which is located in a particular city, and contributors to the repo can add a new restaurant as a simple markdown file.
----
 
 I just had to solve a conundrum wherein I wanted a custom front matter key, _city_, to have similar features as _tags_, namely:
 

--- a/posts/form-accessibility-beyond-basics-popetech.md
+++ b/posts/form-accessibility-beyond-basics-popetech.md
@@ -10,6 +10,5 @@ tags:
 linkTarget: https://blog.pope.tech/2023/09/26/form-accessibility-and-usability-beyond-the-basics/
 ---
 Whitney Lewis covers four accessibility considerations for implementing forms: autofill, error messaging, date fields and auto-formatting fields.
----
 
 I found the explanatations of the `autocomplete` attribute and the section on an accessible error message pattern particularly useful. The latter part felt similar to the good advice Adam Silver gives in his book Form Design Patterns.

--- a/posts/fringe-making.md
+++ b/posts/fringe-making.md
@@ -10,7 +10,6 @@ tags:
   - development
 ---
 Last Tuesday, 20/8/19 I made the train trip east for a day at the Edinburgh Festival Fringe.
----
 
 There are always a variety of interesting shows to catch in the month-long festival and this year I was particularly looking foward to Darren McGarvey <abbr>AKA</abbr> Loki’s _Scotland Today_. Having <a href="{{ '/posts/poverty-safari-by-darren-mcgarvey/' | url }}">read and enjoyed</a> McGarvey’s book _Poverty Safari_ last year I was keen to see and hear him in the flesh.
 

--- a/posts/from-dynamic-to-static.md
+++ b/posts/from-dynamic-to-static.md
@@ -16,7 +16,6 @@ tags:
 draft: false
 ---
 “I’ll just make a few small tweaks to my website…” said I. Cut to three sleep-deprived days later and I’ve rebuilt it, SSG/JAMstack-stylee with Eleventy and Netlify and entirely re-coded the front-end. Silly, but so far so good, and it’s greasy fast!
----
 
 So yes, I’ve just updated my website from being a dynamic, LAMP-stack affair which used Perch CMS and was hosted on Linode to being statically-generated using Eleventy and hosted on Netlify.
 

--- a/posts/front-end-architecture-for-a-new-website-in-2021.md
+++ b/posts/front-end-architecture-for-a-new-website-in-2021.md
@@ -27,7 +27,6 @@ draft: false
 
 ---
 Just taking a moment for some musings on which way the front-end wind is blowing (from my perspective at least) and how that might practically impact my approach on the next small-ish website that I code.
----
 
 ## I might lean into HTTP2
 

--- a/posts/full-disclosure.md
+++ b/posts/full-disclosure.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 Whether I’m thinking about inclusive hiding, hamburger menus or web components one UI pattern I keep revisiting is the _disclosure widget_. Perhaps it’s because you can use this small pattern to bring together so many other wider aspects of good web development. So for future reference, here’s a braindump of my knowledge and resources on the subject.
----
 
 A disclosure widget is for collapsing and expanding something. You might alternately describe that as hiding and showing something. The reason we collapse content is to save space. The thinking goes that users have a finite amount of screen estate (and attention) so we might want to reduce the space taken up by secondary content, or finer details, or repeated content so as to push the page’s key messages to the fore and save the user some scrolling. With a disclosure widget we collapse detailed content into a smaller snippet that acts as a button the user can activate to expand the full details (and collapse them again).
 

--- a/posts/fuzzy-logic-laurence-hughes-feb-23-clyde-built-radio.md
+++ b/posts/fuzzy-logic-laurence-hughes-feb-23-clyde-built-radio.md
@@ -21,7 +21,6 @@ openGraphImage: "https://res.cloudinary.com/fuzzylogic/image/upload/q_auto,f_aut
 draft: false
 ---
 Having pre-recorded previous shows, I recently made a first visit to [Clyde Built Radio’s](https://www.clydebuiltradio.com/) station at the Barras market for a live show and really enjoyed it. It’s such a great location and it was a nice change to spin records on a Sunday morning.
----
 
 {% if app.environment == "production" %}
 

--- a/posts/fuzzy-logic-laurence-hughes-march-23-clyde-built-radio.md
+++ b/posts/fuzzy-logic-laurence-hughes-march-23-clyde-built-radio.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 I recorded my second radio show of 2023 live at the Clyde Built Radio studio at the weekend. It was great playing records there on a sunny Sunday with the clocks just gone forward and the Barras buzzing as it hosted a Hong Kong street market.
----
 
 {% if app.environment == "production" %}
 

--- a/posts/fuzzy-logic-show-rbv-220423.md
+++ b/posts/fuzzy-logic-show-rbv-220423.md
@@ -12,7 +12,6 @@ draft: false
 
 ---
 My latest radio show is dedicated to Ryuichi Sakamoto, who sadly died recently. I played a couple of tracks by the great man alongside more of my favourite music.
----
 
 [Listen to the show on Soundcloud.](https://soundcloud.com/radiobuenavida/fuzzy-logic-w-laurence-hughes-radio-buena-vida-220423)
 

--- a/posts/gap-versus-margin-in-css.md
+++ b/posts/gap-versus-margin-in-css.md
@@ -23,7 +23,6 @@ draft: true
 
 ---
 `gap` is great and in many ways feels _superior_ to margin. And now that all modern browsers support `gap` for both grid and flexbox it‘s tempting to want to use it on every multi-item layout that requires space between items, replacing our previous `margin`-based implementations. Adam Argyle in particular has popularised the concept of using CSS Grid [just for gap](https://web.dev/building-a-settings-component/#just-for-gap) and suggested that [gap will become the primary way we space elements on the web](https://dev.to/argyleink/5-css-predictions-for-2020-pl3). But is `gap` _always_ the best choice?
----
 
 (v. useful reference https://every-layout.dev/blog/second-edition/)
 

--- a/posts/getting-into-into-the-spirit-of-alba.md
+++ b/posts/getting-into-into-the-spirit-of-alba.md
@@ -13,7 +13,6 @@ location: Kirkintilloch
 Mick had been saying for a couple of years that I should join him, sister Jenny and brother-in-law Barry on one of their jaunts to the annual Spirit of Alba festival at Kirkintilloch Town Hall. I’d always felt it’d be a nice opportunity for us to hang out (with the added bonus of whisky tasting) so yesterday I took him up on the offer.
 
 Last time I was at Kirky town hall was probably for a disco as a teenager and I must say the venue and surrounding area are looking nice after recent work. It’s cool that my hometown has a whisky festival given its historic role in whisky’s global story – see [Rita Cowan](https://www.eastdunbarton.gov.uk/news/kirkintilloch-woman-who-became-whisky-pioneer-japan-remembered) and the [Japanese brand Nikka](https://www.nikka.com/eng/story/founder/) for more. It’s also quite the turnaround given Kirky was a dry town til the 70s.
----
 
 I don’t have the constitution to go straight into the hard stuff so my first drink was [Das ist ein lagerbier](https://www.upfrontbrewing.com/shop/8uxlsnaosakrfdt2ealrfhffinepoi-rlnmg), a Helles from Upfront Brewing. It turns out that amiable owner Jake lives near me in the southside. It was then onto whisky tasters from [The Glasgow Distillery’s lovely 1770 range](https://www.glasgowdistillery.com/browse/c-1770-Single-Malt-Whisky-2/), [Angels’ Nectar](https://www.angelsnectar.co.uk/en/home.php) and [JG Thomson](https://jgthomson.com/shop).
 

--- a/posts/getting-started-with-css-cascade-layers-by-stephanie-eckles.md
+++ b/posts/getting-started-with-css-cascade-layers-by-stephanie-eckles.md
@@ -24,7 +24,6 @@ draft: false
 Yesterday I read [Eric Meyer discussing CSS Cascade Layers](https://aneventapart.com/news/post/looking-ahead-june-2022) and commenting that the speed at which it had transitioned from first public working draft to shipping as a full public release in every major desktop and mobile browser had made his head spin. Amazing stuff and an indicator of the turbo-boosted pace at which modern CSS is now evolving.
 
 It also made me want to properly read up on Cascade Layers, because I knew some of the theory but now wanted to consider using it in practice. I’m no great fan of “cascade-taming” CSS frameworks like BEM and SUIT (although I acknowledge why we have them) so I’m interested to know if Cascade Layers can replace them. Stephanie Eckles’ article is an excellent primer.
----
 
 I liked the idea of a specifying a stack like this:
 

--- a/posts/gil-scott-heron-saved-me.md
+++ b/posts/gil-scott-heron-saved-me.md
@@ -6,6 +6,5 @@ tags: [link, music]
 linkTarget: https://www.theguardian.com/music/2011/jun/19/gil-scott-heron-saved-me
 ---
 From _The Guardian_ in 2011, shortly after Gil Scott-Heron’s sad death, here’s a beautiful and moving account of how the musical legend offered hope and mentorship to a young man from Liverpool and in so doing turned his life around.
----
 
 Thanks to Nick Peacock for [sharing](https://www.facebook.com/nick.peacock.944/posts/2353365751547889). 

--- a/posts/glesga-on-film-and-tough-luck-event-at-signal-sounds.md
+++ b/posts/glesga-on-film-and-tough-luck-event-at-signal-sounds.md
@@ -16,6 +16,5 @@ location: Signal Sounds, Howard St, Glasgow
 Glad I accepted the invite from Jason and Tom to attend their [in-store event](https://www.signalsounds.com/blog?p=signal-sounds-vs-tough-luck). After some free beer and pizza, Luke introduced Jordan from _Tough Luck_, an Instagram account spotlighting up-and-coming youth culture photographers. He interviewed Glasgow photographer Selina Paton ([@glesgaonfilm](https://www.instagram.com/glesgaonfilm/)). I ended up sat next to Selina’s Dad for that part!
 
 A book entitled [Tough Luck: You out tonight?](https://velocitypress.uk/product/tough-luck-you-out-tonight-book/) is out now on Velocity Press. I got a lovely sense of enthusiasm for clubs and club culture from the guests, and enjoyed their analogy about film versus digital photography being a bit like vinyl versus digital audio – it’s just different and you can’t recreate the feel retrospectively.
----
 
 Aside from Tom and Jason it was also nice to see and chat to folks like Lydia (and her friendly crew of edgelord neighbours), Dom C and Hayley.

--- a/posts/goldman-sachs-design-system.md
+++ b/posts/goldman-sachs-design-system.md
@@ -19,7 +19,6 @@ draft: false
 
 ---
 This Design System reference website sports a smart architecture with some interesting sections.
----
 
 The components are neatly organised into categories. And I like the _Foundations_ area which includes a [Design System Concepts](https://design.gs.com/foundation/design-system-concepts) section serving as a glossary of property and anatomical terms, plus an Accessibility section with neat diagrams.
 

--- a/posts/gov.uk-visitor-stats-for-january-2022.md
+++ b/posts/gov.uk-visitor-stats-for-january-2022.md
@@ -47,6 +47,5 @@ Thanks once again to Matt Hobbs and GOV.UK for sharing their website visitor sta
 —Matt Hobbs, [@TheRealNooshu](https://twitter.com/TheRealNooshu)
 
 In particular, their “usage by device type” stats see mobile at ~67%, Desktop at ~30.5%, Tablet at ~2.5%.
----
 
 In terms of comparative traffic, according to [Simliar Web’s Top 10 most visited UK websites list](https://www.similarweb.com/top-websites/united-kingdom/) they’re hovering around #10.

--- a/posts/guest-reggae-and-dub-mix-on-vic-s-sunday-soundclash.md
+++ b/posts/guest-reggae-and-dub-mix-on-vic-s-sunday-soundclash.md
@@ -25,7 +25,6 @@ draft: false
 A couple of weeks ago I was kindly asked to provide a guest DJ mix for the Vic’s Sunday Soundclash show on Radio Magnetic.
 
 You can [listen to the show](https://www.mixcloud.com/RadioMagnetic/vics-sunday-soundclash-08-w-laurence-hughes/) on demand.
----
 
 Here’s the tracklist for my mix:
 

--- a/posts/handoff-versus-collaboration.md
+++ b/posts/handoff-versus-collaboration.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 I’m a fan of web designers and developers collaborating closely rather than designers throwing mock-ups over the wall. Recently I read two newsletters relating to this topic, or perhaps more accurately about perceived divisions between design and development and some better, more modern ways of thinking.
----
 
 The first, [The best handoff is no handoff](https://mailchi.mp/smashingmagazine.com/better-design-estimates-1134673?e=854bbd5846) from Smashing Magazine, presents alternatives to waterfall including [The Hot Potato Process](https://danmall.com/posts/hot-potato-process/) espoused by Brad Frost and Dan Mall. 
 

--- a/posts/happy-anniversary-folks.md
+++ b/posts/happy-anniversary-folks.md
@@ -15,7 +15,6 @@ location: Glasgow
 ---
 I’ve reached the halfway point of short summer working weeks and long weekends, and they’ve been great so far. I began this long weekend with lunch at the [Broadcroft Hotel](https://www.broadcrofthotel.com/) in Kirkintilloch for my parents’ emerald anniversary. My Uncle Liam was there too and we all really enjoyed it.
 
----
 
 I had panko breaded Stornoway black pudding with apricot & plum chutney to start, followed by fish pie, then a coffee to finish. In the words of Larry David it was all pretty, pretty good. It’s also pretty, pretty impressive that my folks have been married fifty-five years. My mum was delighted to find a specific Emerald Anniversary card to give Dad, which contained some amusing words about their steadfast love!
 

--- a/posts/harry-roberts-says-get-your-head-straight.md
+++ b/posts/harry-roberts-says-get-your-head-straight.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 Harry Roberts (who created ITCSS for organising CSS at scale but these days focuses on performance) has just given a presentation about the importance of getting the content, order and optimisation of the `<head>` element right, including lots of measurement data to back up his claims. Check out the slides: [Get your Head Straight](https://speakerdeck.com/csswizardry/get-your-head-straight)
----
 
 While some of the information about asset loading best practices is not new, the stuff about _ordering_ of `head` elements is pretty interesting. I’ll be keeping my eyes out for a video recording of the presentation though, as it’s tricky to piece together his line of argument from the slides alone. 
 

--- a/posts/heather-buchel-its-2023-heres-why-your-design-sucks.md
+++ b/posts/heather-buchel-its-2023-heres-why-your-design-sucks.md
@@ -23,7 +23,6 @@ draft: false
 Heather explores why we no longer have “web designers”. 
 
 > It's been belittled and othered away. It's why we've split that web design role into two; now you're either a UX designer and you can sit at that table over there or you're a front-end developer and you can sit at the table with the people that build websites.
----
 
 Heather makes lots of good points in this post. But the part that resonates most with me is the observation that we have split design and engineering in a way that is dangerous for building proper websites. 
 

--- a/posts/henke-tramway.md
+++ b/posts/henke-tramway.md
@@ -24,7 +24,6 @@ tags:
 draft: false
 ---
 Over the years I’ve seen Herr Henke (of [Monolake](https://www.discogs.com/artist/534-Monolake) fame) doing variously-themed live shows and in a variety of locations. I loved [this particular show](https://roberthenke.com/concerts/cbm8032av.html) and it was made even better by catching him at [The Tramway Theatre](https://www.tramway.org/about-tramway/), one of my favourite venues and just 10 minutes walk from home.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/hijack-003-jamie-thomson.md
+++ b/posts/hijack-003-jamie-thomson.md
@@ -14,6 +14,5 @@ draft: false
 Lovely house mix from my friend Jamie.
 
 <iframe width="100%" height="300" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A//api.soundcloud.com/tracks/911664106&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true&visual=true"></iframe>
----
 
 Lots of good stuff in here, with plenty I don’t know plus a few classics from Crustation (Mood 11 Swing’s mix of _Flame_) and Chez ’n’ Trent.

--- a/posts/holiday-to-provence-july-2022.md
+++ b/posts/holiday-to-provence-july-2022.md
@@ -11,7 +11,6 @@ tags:
   - food
 ---
 Like most folks we didn’t holiday abroad during 2020 and 2021, when COVID was at its height. Trips abroad are a luxury and privilege so this was no hardship. However I’ll admit that once restrictions were lifted and things felt safer, we were pretty excited to head for some sun and good food, and set our sights on a first trip together to the south of France.
----
 
 ## The location
 

--- a/posts/how-i-consume-and-read-rss-feeds.md
+++ b/posts/how-i-consume-and-read-rss-feeds.md
@@ -13,7 +13,6 @@ tags:
 ---
 I’m currently interested in how to spend less time on social media platforms so as to be less exposed to ads, algorithms and general ill-effects. One approach I’m trialling is going back to the old school and using [RSS](https://en.wikipedia.org/wiki/RSS) to receive and aggregate updates from the people I follow, allowing me to read them in a central, noise-free place and not have to use social platform websites and apps.
 
----
 
 I use the free, open source Mac and iOS app [NetNewsWire](https://ranchero.com/netnewswire/) on my MacBook. This is where I tend to add and organise my RSS feeds as it has a good UI, for example for arranging feeds into suitable folders.
 

--- a/posts/how-i-subset-web-fonts.md
+++ b/posts/how-i-subset-web-fonts.md
@@ -15,7 +15,6 @@ tags:
 On [my personal website](https://fuzzylogic.me) I currently use three web fonts from the _Source Sans 3_ group: regular, italic and semibold. I self-host my fonts because [that’s a good practice](https://csswizardry.com/2019/05/self-host-your-static-assets/). Additionally I use a variety of special characters to add some typographic life to the text.
 
 When self-hosting it’s important from a performance perspective to minimise the weight of the font files your visitors must download. To achieve this I subset my fonts so as to include only the characters my pages use but no more. Here’s how I do it.
----
 
 Note: to follow these steps, you’ll need to install [glyphhanger](https://github.com/filamentgroup/glyphhanger). The Github page includes installation and usage guidelines however there are a few common installation pitfalls so if you’re on a Mac and run into trouble I recommend checking Sara Soueidan’s [_How I set up Glyphhanger on macOS_](https://www.sarasoueidan.com/blog/glyphhanger/) to get you back on track.
 

--- a/posts/how-to-break-out-to-full-bleed-various-ways.md
+++ b/posts/how-to-break-out-to-full-bleed-various-ways.md
@@ -11,7 +11,6 @@ tags:
   - fullbleed
 ---
 How to break out to full-bleed, various ways.
----
 
 Adactio mentioned this article https://joshwcomeau.com/css/full-bleed/.
 

--- a/posts/how-to-build-an-accesssible-autocomplete.md
+++ b/posts/how-to-build-an-accesssible-autocomplete.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 At work there are plans afoot to reconcile various differing _Autocomplete_ implementations into a single, reusable component. So far there’s been a written audit presenting all instances and how they differ in functional and technical respects. There’s also been design work to identify visual commonalities and avoid future inconsistencies. I’d now like to add another perspective: an investigation into which HTML materials and (if necessary) ARIA supplements are appropriate to ensure we build something accessible and resilient.
----
 
 My experience is that to achieve the right result, HTML semantics and related concerns can’t just follow and bend to spec and visual design goals, but rather must _influence_ the setting of those goals.
 

--- a/posts/how-to-choose-an-appropriate-accessibility-standard-for-your-website-and-test-against-it.md
+++ b/posts/how-to-choose-an-appropriate-accessibility-standard-for-your-website-and-test-against-it.md
@@ -5,7 +5,6 @@ date: "2020-09-20T16:58:08.051Z"
 tags: [web, development, a11y, howto]
 ---
 When advocating accessible web practices for a commercial website, the question of “what does the law require us to do?” invariably arises.
----
 
 The appropriate answer to that question should really be that it doesn’t matter. Regardless of the law there is a moral imperative to do the right thing unless you are OK with excluding people, making their web experiences unnecessarily painful, and generally flouting the web’s founding principles.
 

--- a/posts/how-to-control-svg-icon-size-and-colour-in-context.md
+++ b/posts/how-to-control-svg-icon-size-and-colour-in-context.md
@@ -5,7 +5,6 @@ date: 2019-04-01 13:25:00
 tags: [development,svg,css,viewbox,currentColor,aria]
 ---
 A while back I read [a great SVG icon tip from Andy Bell](https://twitter.com/andybelldesign/status/1098915626050117633) which I’d been meaning to try and finally did so today. Andy recommended that for icons with text labels we set the `width` and `height` of the icons to `1em` since that will size them proportionately to the adjacent text and additionally lets us use `font-size` to make any further sizing tweaks.
----
 
 As [previously mentioned](https://fuzzylogic.me/thoughts/grey-scales-something-fishy-with-svg), I’ve recently been working on my SVG skills.
 

--- a/posts/how-to-hide-elements-for-different-browsing-contexts.md
+++ b/posts/how-to-hide-elements-for-different-browsing-contexts.md
@@ -12,7 +12,6 @@ tags:
 - hiding
 ---
 In order to code modern component designs we often need to hide then reveal elements. At other times we want to provide content to one type of user but hide it from another because it’s not relevant to their mode of browsing. In all cases accessibility should be front and centre in our thoughts. Here’s my approach, heavily inspired by Scott O’Hara’s definitive guide [Inclusively Hidden](https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html).
----
 
 Firstly, _avoid_ the need to hide stuff. With a bit more thought and by using existing fit-for-purpose HTML tools, we can perhaps create a single user interface and experience that works for all. That approach not only feels like a more equal experience for everyone but also removes margin for error and code maintenance overhead.
 

--- a/posts/how-to-manage-javascript-dependencies.md
+++ b/posts/how-to-manage-javascript-dependencies.md
@@ -5,7 +5,6 @@ date: "2019-10-23T16:58:08.051Z"
 tags: [entry, development, javascript, yarn, npm, nodejs, tooling, howto]
 ---
 Managing JavaScript dependencies is about as much fun as a poke in the eye. However even if—like me—you prefer to keep things [lean](https://leanweb.dev/) and dependency-free as far as possible, it’s something you’re going to need to do either in large work projects or as your personal side-project grows. In this post I tackle it head-on to reduce the problem to some simple concepts and practical techniques.
----
 
 In modern JavaScript applications, we can add tried-and-tested open source libraries and utilities by installing [packages](https://docs.npmjs.com/about-packages-and-modules) from the [NPM registry](https://www.npmjs.com/). This can aid development by letting you concentrate on your application’s _unique features_ rather than reinventing the wheel for already-solved common tasks.
 

--- a/posts/html-with-superpowers-from-dave-rupert.md
+++ b/posts/html-with-superpowers-from-dave-rupert.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 Here’s a great new presentation by Dave Rupert (of the [Shop Talk](https://shoptalkshow.com/) show) in which he makes a compelling case for adopting Web Components. Not only do they provide the same benefits of encapsulation and reusability as components in proprietary JavaScript frameworks, but they also bring the reliability and portability of web standards, work without build tools, are suited to progressive enhancement, and may pave the way for a better web. 
----
 
 Dave begins by explaining that Web Components are based on not just a set of technologies but a set of _standards_, namely:
 

--- a/posts/images-the-big-picture-part-2.md
+++ b/posts/images-the-big-picture-part-2.md
@@ -11,7 +11,6 @@ permalink: /posts/images-on-the-web-the-big-picture-part-2/
 draft: true
 ---
 lorem
----
 
 ## Modern Responsive Images
 

--- a/posts/images-the-big-picture.md
+++ b/posts/images-the-big-picture.md
@@ -11,7 +11,6 @@ tags:
 permalink: /posts/images-on-the-web-the-big-picture/
 ---
 In modern web development there are a myriad ways to present an image on a web page and it can often feel pretty baffling. In this series I step through the options, moving from basic to flexible images; then from modern responsive images to the new CSS for fitting different sized images into a common shape. By the end I’ll arrive at a flexible, modern boilerplate for images.
----
 
 ## Scope
 

--- a/posts/improved-focus-indicators-for-keyboard-navigation-on-github-s-blog.md
+++ b/posts/improved-focus-indicators-for-keyboard-navigation-on-github-s-blog.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 GitHub have recently done some good work on improving keyboard navigation for (and general usability of) their focusable elements such as links, buttons and form controls by improving focus indication. And then they wrote a short-but-sweet article about it, then [tweeted to share that](https://twitter.com/KatieLangerman/status/1519397715859312640) and their work is getting lots of positive recognition from all the right people. Nice job all round, GitHub!
----
 
 Incidentally, that article they wrote really is _very_ short. Maybe they’ll add to it later. The animated gif they include is very descriptive, mind you. And I noticed that they added the following `alt` text to it:
 

--- a/posts/improving-alternative-text-for-images.md
+++ b/posts/improving-alternative-text-for-images.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 Some colleagues at work have recently been asking interesting questions about “good/appropriate alternative text for images”. I definitely reckon it’s a topic worth revisiting because it feels like the landscape has changed a bit on this front over the years.
----
 
 I think the web design industry has traditionally been:
 

--- a/posts/in-the-devtools-console.md
+++ b/posts/in-the-devtools-console.md
@@ -25,7 +25,6 @@ draft: false
 I learned something new today when developing in the Firefox Dev Tools console (although this applies to Chrome too)—something which was really useful and which I thought I’d share.
 
 Basically, type `$$('selector')` into the console (replacing _selector_ as desired) and it’ll give you back all matching elements on the page.
----
 
 So for example, `$$('script')` or `$$('li')`.
 

--- a/posts/inclusive-user-research-recruiting-participants-by-ela-gorla-on-tetralogical-s-blog.md
+++ b/posts/inclusive-user-research-recruiting-participants-by-ela-gorla-on-tetralogical-s-blog.md
@@ -14,6 +14,5 @@ draft: false
 
 ---
 Tetralogical are doing a great series of articles on _running inclusive research_. Their latest is about recruiting participants and covers whether you should recruit people with disabilities as part of your testing and if so who, and how many, and how to recruit them.
----
 
 Previous articles addressed moderating usability testing sessions with people with disabilities, and analysing findings from inclusive user research.

--- a/posts/inline-block-versus-flexbox-for-horizontal-arrangements.md
+++ b/posts/inline-block-versus-flexbox-for-horizontal-arrangements.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 Something I’ve found interesting while reviewing recent code test submissions (within job applications) at work is that more developers than I’d expect still use `display: inline-block` when they need to lay out multiple elements horizontally such as the items in a navigation menu. It’s interesting because Flexbox – which has now been around for almost 10 years – gives you a modern, purpose-built solution to that.
----
 
 Of course, there is no _crime_ in taking the `inline-block` approach. It’s an option. And I did take a moment just to challenge my assumptions. But having given it a little thought, I am pretty convinced that Flexbox is the better approach and so I think their choice is worth a query. 
 

--- a/posts/interview-question-answer.md
+++ b/posts/interview-question-answer.md
@@ -22,7 +22,6 @@ draft: false
 There’s a classic web developer interview question that goes something like this:
 
 What happens when you type in “bbc.co.uk” into a browser? Describe the journey that results in you seeing a page.
----
 
 You could answer it like this:
 

--- a/posts/into-the-outer-w-other-lands-firecracker-27th-october-2018-on-nts.md
+++ b/posts/into-the-outer-w-other-lands-firecracker-27th-october-2018-on-nts.md
@@ -6,9 +6,8 @@ tags: [link, music, radio, firecracker, otherlands, nts, thenuclearfamily]
 linkTarget: "https://www.nts.live/shows/lindsay-todd/episodes/into-the-outer-27th-october-2018"
 ---
 Magical sounds in the mix, from Auld Reekie’s finest.
----
 
-Other Lands consistently plays amazing records. 
+Other Lands consistently plays amazing records.
 
 He’s also been cultivating a quirky but cuddly radio voice which, combined with the heartfelt electronic sounds, makes for a warm and fuzzy listen.
 

--- a/posts/intrinsically-responsive-css-grid-with-minmax-and-min.md
+++ b/posts/intrinsically-responsive-css-grid-with-minmax-and-min.md
@@ -11,7 +11,6 @@ tags:
 linkTarget: http://evanminto.com/blog/intrinsically-responsive-css-grid-minmax-min/
 ---
 Evan Minto notes that flexible grids created with CSS Grid’s `repeat`, `auto-fill`, and `minmax` are only intrinsically responsive (responsive to their _container_ rather than the viewport) up to a point, because when the container width is narrower than the minimum width specified in `minmax` the grid children overflow.
----
 
 Applying media queries to the grid is not a satisfactory solution because they relate to the the viewport (hence why [Every Layout](https://every-layout.dev/) often prefer Flexbox to CSS Grid because it allows them to achieve intrinsic responsiveness).
 

--- a/posts/invisible-success-bailey.md
+++ b/posts/invisible-success-bailey.md
@@ -21,14 +21,13 @@ Here’s Eric Bailey with some very relatable thoughts on the need to tell desig
   <p>This is objectively great. The problem, however, is how we talk, or fail to talk about this type of success.</p>
 </blockquote>
 
----
 
 > A lack of bug reports, accessibility issues, design tweaks, etc. are all objectively great, but there are no easy datapoints you can measure here. By this, I mean it is difficult to quantify a void.
 
 Eric advices crafting stories about the important aspects of design system work that are not directly about components:
 
 <blockquote>
-  
+
   - Identifying and collecting various ways to weave compelling narratives about the invisible, successful work you’ve done, and then
   - Putting those stories in front of the people who need to know them.
 

--- a/posts/issues-with-source-code-pro-in-firefox-appear-to-be-fixed.md
+++ b/posts/issues-with-source-code-pro-in-firefox-appear-to-be-fixed.md
@@ -14,7 +14,6 @@ tags:
 draft: false
 ---
 Last time I tried [Source Code Pro](https://github.com/adobe-fonts/source-code-pro) as my monospaced typeface for code examples in blog posts, it didn’t work out. When viewed in Firefox it would only render in black meaning that I couldn’t display it in white on black for blocks of code. This led to me conceding defeat and using something simpler.
----
 
 It now looks like I can try Source Code Pro again because [the issue has been resolved](https://github.com/adobe-fonts/source-code-pro/issues/250#issuecomment-728646917). This is great news!
 

--- a/posts/it-all-means-nothing.md
+++ b/posts/it-all-means-nothing.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 In this talk at State of the Browser, Amy offers some suggestions for making work feel more meaningful.
----
 
 <div class="l-frame"><iframe title="It all means nothing in the end (talk by Amy Hupe)" width="560" height="315" src="https://www.youtube.com/embed/Q0v2YJLq8n8?si=NYC7NO8N1kqBvkBP" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 

--- a/posts/i’ve-just-read-the-inner-game-of-tennis-by-timothy-gallwey.md
+++ b/posts/i’ve-just-read-the-inner-game-of-tennis-by-timothy-gallwey.md
@@ -11,7 +11,6 @@ tags:
 description: I’ve just read The Inner Game of Tennis, by Timothy Gallwey
 ---
 This was an interesting read, recommended by some experienced players at my table tennis club. (The book focuses on tennis but most of it is transferable). This tip came at a good time, as I’m looking to reduce tension from my game.
----
 
 The author presents the following ideas: 
 

--- a/posts/jank-free-responsive-images.md
+++ b/posts/jank-free-responsive-images.md
@@ -5,7 +5,6 @@ date: 2019-10-23
 tags: [web, development, rwd, images, jensimmons, firefox, chrome]
 ---
 Here’s how to improve performance and prevent layout _jank_ when browsers load responsive images.
----
 
 Since the advent of the Responsive Web Design era many of us, in our rush to make images flexible and adaptive, stopped applying the HTML `width` and `height` attributes to our images. Instead we’ve let CSS handle the image, setting a `width` or `max-width` of 100% so that our images can grow and shrink but not extend beyond the width of their parent container.
 
@@ -19,7 +18,7 @@ The other day I was testing [this here website](https://fuzzylogic.me/) in Chrom
 
 Based on that, I made the following updates:
 
-1. I added width and height HTML attributes to all images; and 
+1. I added width and height HTML attributes to all images; and
 2. I changed my CSS from `img { max-width: 100%; }` to `img { width: 100%; height: auto; }`.
 
 NB the reason behind #2 was that I found that that CSS works better with an image with inline dimensions than `max-width` does.
@@ -28,7 +27,7 @@ NB the reason behind #2 was that I found that that CSS works better with an imag
 
 Since an image’s actual rendered dimensions will depend on the viewport size and we can’t anticipate that viewport size, I plumped for a `width` of 320 (a narrow mobile width) × `height` of 240, which fits with this site’s standard image aspect ratio of 4:3.
 
-I wasn’t sure if this was a good approach. Perhaps I should have picked values which represented the dimensions of the image on desktop. 
+I wasn’t sure if this was a good approach. Perhaps I should have picked values which represented the dimensions of the image on desktop.
 
 ## Jen Simmons to the rescue
 
@@ -46,4 +45,4 @@ I just tested this new feature in Firefox Nightly 72, using the Inspector’s Ne
 
 ## Lazy Loading
 
-One thing I’m keen to test is that my newly-added inline `width` and `height` attributes play well with `loading="lazy"`. I don’t see why they shouldn’t and in fact they should in theory all support each other well. In tests so far everything seems good, however since `loading="lazy"` is currently only implemented in Chrome I should re-test images in Chrome once it adds support for the new image aspect ratio calculating feature, around the end of 2019. 
+One thing I’m keen to test is that my newly-added inline `width` and `height` attributes play well with `loading="lazy"`. I don’t see why they shouldn’t and in fact they should in theory all support each other well. In tests so far everything seems good, however since `loading="lazy"` is currently only implemented in Chrome I should re-test images in Chrome once it adds support for the new image aspect ratio calculating feature, around the end of 2019.

--- a/posts/january-blues-banishing-in-edinburgh.md
+++ b/posts/january-blues-banishing-in-edinburgh.md
@@ -10,7 +10,6 @@ tags:
 draft: false
 ---
 I’m starting 2024 as I mean to continue – by seeing and hanging out with friends more often. Yesterday [Tom](https://tomchurchill.com/) and I had a great day moseying around Edinburgh.
----
 
 After meeting at Waverley and grabbing a quick coffee and bite, we headed to the Scottish National Gallery on The Mound. Tom was keen to see the [Turner watercolours exhibition](https://www.nationalgalleries.org/exhibition/turner-january) which is on every January – apparently the ideal time of year to best show off the works. I probably wouldn’t have visited this unprompted but I’m glad I did. My favourites were perhaps [The Falls of Clyde](https://www.nationalgalleries.org/art-and-artists/19242?collection=46&artwork=37) and [Lake Albano](https://www.nationalgalleries.org/art-and-artists/19238?collection=46&artwork=10).
 

--- a/posts/javascript-arrow-functions.md
+++ b/posts/javascript-arrow-functions.md
@@ -12,7 +12,6 @@ tags:
 draft: false
 ---
 JavaScript arrow functions are one of those bits of syntax about which I occasionally have a brain freeze. Here’s a quick refresher for those moments.
----
 
 <details>
 <summary>Differences between arrow functions and traditional functions</summary>

--- a/posts/javascript-promises-explained.md
+++ b/posts/javascript-promises-explained.md
@@ -12,7 +12,6 @@ tags:
   - asynchronous
 ---
 A brief explainer (for future-me and anyone else it helps) on what promises are and how to use them. Note: this is not an _official_ definition, but rather one that works for me.
----
 
 In the normal run of things, JavaScript code is _synchronous_. When line 1 has run (perhaps defining a new variable) and the operation has completed, line 2 runs (perhaps operating on the variable we just defined). However sometimes in line 1 we need to do something which will take longer – maybe an unknown length of time – for example to call a function which fetches data from an external API. In many cases we don’t mind that taking a while, or even eventually failing, but we want it to execute _separately_ from the main JavaScript thread so as not to hold up the execution of line 2. So instead of waiting for the task to complete and return its value, our API-calling function instead returns a _promise_ to supply that value in the future.
 

--- a/posts/join-the-future.md
+++ b/posts/join-the-future.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 > It’s important to set the record straight. Normally when people talk about the early UK scene the same few things get mentioned. The real underground never gets talked about."
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/just-read-lost-connections.md
+++ b/posts/just-read-lost-connections.md
@@ -13,7 +13,6 @@ draft: false
 
 ---
 When chatting with a consellor in January about some bouts of low mood and mental fatigue, I described one symptom as a strange sense of _disconnection_. And while the recent lockdowns during the pandemic were obvious contributors to that, they didn’t feel like the full story.
----
 
 Reassuringly it seems I’m far from alone in feeling this way, since one of her suggestions was to read Johann Hari’s bestselling book [Lost Connections: why you’re depressed and how to find hope.](https://uk.bookshop.org/p/books/lost-connections-why-you-re-depressed-and-how-to-find-hope-johann-hari/910739?ean=9781408878729)
 

--- a/posts/larry’s-garage.md
+++ b/posts/larry’s-garage.md
@@ -18,6 +18,5 @@ I just watched “Larry’s Garage” – a film by Corrada Rizza about the visi
 <div class="l-frame">
   <iframe title="Larry’s Garage – Larry Levan & The Paradise Garage" loading="lazy" width="640" height="360" src="https://player.vimeo.com/video/470933551" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
----
 
 Unfortunately there’s generally precious little footage of the infamous New York club and what they included I’d seen before, but there was some nice previously unseen interview footage with Larry Levan and overall, although I wasn’t blown away, I enjoyed it.

--- a/posts/lean-plugin-subscription-form-by-chris-ferdinandi.md
+++ b/posts/lean-plugin-subscription-form-by-chris-ferdinandi.md
@@ -9,7 +9,6 @@ draft: false
 
 ---
 I enjoyed this two-part tutorial from Chris arising from his critique of a subscription form plugin which includes the entire React library to achieve what could be done with a lightweight HTML and vanilla JavaScript solution. Chris advocates a progressively-enhanced approach. Instead of rendering the form with JavaScript he renders it in HTML and argues that not only is there no need for the former approach – because forms natively work without JavaScript – but also it only introduces fragility where we could provide resilience.
----
 
 Part one: [Using a wrecking ball when a hammer would suffice](https://gomakethings.com/using-a-wrecking-ball-for-a-problem-that-requires-hammer/)
 

--- a/posts/leaving-facebook-while-retaining-social-connections.md
+++ b/posts/leaving-facebook-while-retaining-social-connections.md
@@ -11,7 +11,6 @@ draft: true
 This is still in draft.
 
 “or breaking out of habitual facebook use"
----
 
 This is still in draft.
 

--- a/posts/lightning-fast-web-performance-course-by-scott-jehl.md
+++ b/posts/lightning-fast-web-performance-course-by-scott-jehl.md
@@ -13,7 +13,6 @@ tags:
   - development
 ---
 I purchased [Scott’s course](https://www.webpagetest.org/learn/lightning-fast-web-performance/) back in 2021 and immediately liked it, but hadn’t found the space to complete it until now. Anyway, I’m glad I have as it’s well structured and full of insights and practical tips. I’ll use this post to summarise my main takeaways.
----
 
 Having completed the course I have much more rounded knowledge in the following areas:
 

--- a/posts/london-trip-july-24.md
+++ b/posts/london-trip-july-24.md
@@ -12,7 +12,6 @@ tags:
 draft: false
 ---
 I had a fantastic time in London last weekend.
----
 
 When my pal Mark visited Glasgow in May for The Queen’s Park Weekender he asked if I’d like to join him on his [Soulsaver boat party](https://ra.co/events/1866753) in July – maybe even to play some records. Since I hadn’t visited him down south for a while I gratefully accepted and put it in the calendar.
 

--- a/posts/long-shot-mix.md
+++ b/posts/long-shot-mix.md
@@ -7,7 +7,6 @@ tags: [entry, music, mix, electronic, house, techno, isonoe]
 A mix of electronic, house and techno records I recorded at home in November 2019.
 
 <iframe title="“Long Shot” DJ mix by The Nuclear Family" width="100%" height="120" src="https://www.mixcloud.com/widget/iframe/?hide_cover=1&hide_artwork=1&feed=%2FTheNuclearFamily%2Ftnf-mix-005-long-shot-november-2019%2F" frameborder="0" ></iframe>
----
 
 2019 has been a fairly quiet year for my and [Tom’s](http://tomchurchill.com/) record label The Nuclear Family. However with a couple of winter events coming up I wanted to share a little teaser mix to whet the collective appetite.
 

--- a/posts/making-coffee-with-sage-barista-touch.md
+++ b/posts/making-coffee-with-sage-barista-touch.md
@@ -9,10 +9,9 @@ tags:
 ---
 Clair recently brought her fancy coffee machine home from work. It’s a Sage Barista Touch. Since then, I’ve been learning what’s involved in making a coffee by grinding fresh from whole beans, barista-style!
 
-It’s more complicated than I would have thought, and has involved lots of learning and trial and error. 
+It’s more complicated than I would have thought, and has involved lots of learning and trial and error.
 
 Here are my go-to resources and my rules-of-thumb. I’m not saying they’re perfect, but they’re working for me! Any additional tips from people more in the know are, of course, very welcome.
----
 
 ## Dialling in: my rule of thumb
 
@@ -22,7 +21,7 @@ Overall I want:
 - a pull where liquid flows from 7 seconds or more, and
 - a conventional yield such as a 2oz double-espresso.
 
-Once you’ve achieved the above from a process of trial and error, dial in the settings (grind, dose) and log any additional notes so that you can easily repeat the same process achieving the same results. 
+Once you’ve achieved the above from a process of trial and error, dial in the settings (grind, dose) and log any additional notes so that you can easily repeat the same process achieving the same results.
 
 ## How it works in practice
 
@@ -32,9 +31,9 @@ Note: before you start, you want your coffee’s roast date to be no more than 3
 
 Fill up the tank with fresh water. Use the hot water feature to pour out some hot water into your mug to warm everything up.
 
-Start with a grind size of 12 and a grind time of 20 seconds (they’re sensible middling starting points). 
+Start with a grind size of 12 and a grind time of 20 seconds (they’re sensible middling starting points).
 
-Place your portafilter with funnel attached on your scales (turned off) then turn on the scales so that they’re zeroed appropriately. 
+Place your portafilter with funnel attached on your scales (turned off) then turn on the scales so that they’re zeroed appropriately.
 
 Remove the portafilter and grind out coffee based on the previously set grind time. Use the scales to check how much you’ve ground. Remove some, or grind and add more, til you have 18g. Jot down how much time it takes to grind 18g.
 
@@ -47,8 +46,8 @@ Place your espresso measuring mug under the portafilter, ready to receive brewed
 Start brewing and note the point when liquid starts flowing. If it starts flowing before seven seconds, set the grind size finer. Get this aspect locked down first.
 
 Once we’ve achieved a good begin-flow point and a steady flow, I want to identify the number of seconds it takes to achieve my target yield – meaning the time at which the crema hits the _2oz double espresso_ line.
-    
-Once you’ve hit your yield, and so long as the time was between 25-35 seconds, taste it. If you like it you could dial in that brew time and stop there. If it’s at say 28+ seconds (indicating that the water’s taking a long time to make its way though the coffee) I might also try increasing the grind size by one (larger grind = less dense = water gets through faster) and seeing if I can achieve the target yield within a few less seconds. 
+
+Once you’ve hit your yield, and so long as the time was between 25-35 seconds, taste it. If you like it you could dial in that brew time and stop there. If it’s at say 28+ seconds (indicating that the water’s taking a long time to make its way though the coffee) I might also try increasing the grind size by one (larger grind = less dense = water gets through faster) and seeing if I can achieve the target yield within a few less seconds.
 
 Another little tweak I sometimes make to achieve the balance of begin-flow-time, steady flow and yield is to slightly increase or reduce the amount of coffee. For example adding a few milligrams (a dose of 18.5g versus 18g) might start the flow just a little later, when that’s what you need.
 

--- a/posts/manage-design-tokens-in-eleventy.md
+++ b/posts/manage-design-tokens-in-eleventy.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 One interesting aspect of the [Duet Design System](https://www.duetds.com/) is that they use [Eleventy](https://www.11ty.dev/) to not only generate their reference website but also to generate their Design Tokens.
----
 
 When I think about it, this makes sense. Eleventy is basically a sausage-machine; you put stuff in, tell it how you want it to transform that stuff, and you get something new out the other end. This isn’t just for markdown-to-HTML, but for a variety of formatA-to-formatB transformation needs… including, for example, using JSON to generate CSS.
 

--- a/posts/matt-wilde-hello-world.md
+++ b/posts/matt-wilde-hello-world.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 Love [Matt Wilde’s](https://www.mattwilde.com/) music and his new LP _Hello World_ is even better than expected. Beautiful laid-back and understated vibe from start to finish. Lovely artwork too.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/meet-the-new-dialog-element.md
+++ b/posts/meet-the-new-dialog-element.md
@@ -6,7 +6,6 @@ tags: [link, web, development, html, popup, modal]
 linkTarget: https://keithjgrant.com/posts/2018/01/meet-the-new-dialog-element/
 ---
 Introducing `dialog`: a new, easier, standards-based means of rendering a popup or modal dialogue.
----
 
 The new element can be styled via CSS and comes with Javascript methods to show and close a dialog. We can also listen for and react to the show and close events.
 

--- a/posts/min-max-clamp-calculator-by-9elements.md
+++ b/posts/min-max-clamp-calculator-by-9elements.md
@@ -26,7 +26,6 @@ draft: false
 Here’s a handy tool from the smart folks at 9elements for making a value – such as a font-size, or margin – _fluidly responsive_. In their words the tool…
 
 > calculates the CSS clamp formula to interpolate between two values in a given viewport range.
----
 
 It’s inspired by [Utopia](https://utopia.fyi/) but is for situations when you only need a single clamp formula rather than one for each interval in a type or spacing scale.
 

--- a/posts/minimum-viable-web-component-by-zach-leatherman.md
+++ b/posts/minimum-viable-web-component-by-zach-leatherman.md
@@ -11,7 +11,6 @@ draft: false
 
 ---
 [Zach tweeted](https://twitter.com/zachleat/status/1282807913501859841) last year to share a codepen which illustrates the very simple boilerplate needed for a minimum viable web component. Note: his example is so simple that in this case the JavaScript isn’t actually needed for the custom element to work, however the provided JS is a starting point for when you do actually intend to add JS-driven features.
----
 
 The HTML: 
 

--- a/posts/modern-font-stacks.md
+++ b/posts/modern-font-stacks.md
@@ -19,7 +19,6 @@ draft: false
 
 ---
 > System font stack CSS organized by typeface classification for every modern OS. The fastest fonts available. No downloading, no layout shifts, no flashes — just instant renders.
----
 
 This is a great resource for when you want a particular style of font (workhorse sans-serif, grotesque, monospace, display slab serif etc) and to favour a system font rather than a custom font to get performance and simplicity benefits allied to having many weights and characters natively available.
 

--- a/posts/motion-one-the-web-animations-api-for-everyone.md
+++ b/posts/motion-one-the-web-animations-api-for-everyone.md
@@ -26,7 +26,6 @@ draft: false
 
 ---
 > A new animation library, built on the Web Animations API for the smallest filesize and the fastest performance.
----
 
 This JavaScript-based animation library—which can be installed via npm—leans on [an existing web API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API) to keep its file size low and uses hardware accelerated animations where possible to achieve impressively smooth results.
 

--- a/posts/museum-of-the-moon-at-mackintosh-queens-cross.md
+++ b/posts/museum-of-the-moon-at-mackintosh-queens-cross.md
@@ -5,7 +5,6 @@ date: 2018-06-23 19:36:00
 tags: [entry, moon, family, mackintosh]
 ---
 Today I and my brother Martin and two nieces Sophie and Mia, made a first visit to the [Mackintosh Church](http://www.mackintoshchurch.com/) in Maryhill, Glasgow.
----
 
 We were there to visit _Museum of the Moon_, a new touring artwork by UK artist [Luke Jerram](https://www.lukejerram.com/). I’d first heard about this exhibition when watching the BBC documentary [_Wonders of the Moon_](https://www.bbc.co.uk/programmes/b09qjl7g).
 

--- a/posts/my-2023-in-review.md
+++ b/posts/my-2023-in-review.md
@@ -9,7 +9,6 @@ tags:
 - 2023
 ---
 How was 2023 for you? For me, it was like this.
----
 
 ## Music gigs
 

--- a/posts/my-codepen-cheatsheet.md
+++ b/posts/my-codepen-cheatsheet.md
@@ -5,7 +5,6 @@ date: "2020-02-24T20:52:08.051Z"
 tags: [development, codepen, cheatsheet]
 ---
 I’m finding Codepen to be more and more valuable not only for testing out new code and ideas, but also – when working on large applications – as a time-saving rapid prototyping environment which sidesteps the overhead of back-end set-up. Here are some tips which I’ve found useful, for future reference.
----
 
 ## Control the Editor View layout
 

--- a/posts/my-command-line-cheatsheet.md
+++ b/posts/my-command-line-cheatsheet.md
@@ -5,7 +5,6 @@ date: "2020-12-28T16:58:08.051Z"
 tags: [development, cheatsheet, terminal, iterm, iterm2, zsh, ohmyzsh]
 ---
 Here’s a list of useful terminal commands for my reference and yours.
----
 
 ## Using iTerm2 (Terminal Emulator)
 

--- a/posts/my-devtools-cheatsheet.md
+++ b/posts/my-devtools-cheatsheet.md
@@ -14,7 +14,6 @@ tags:
   - cheatsheet
 ---
 Here’s a (work in progress) list of useful (Mac) Browser DevTools tips, tricks and keyboard shortcuts for my reference and yours. This is a work in progress and I’ll update it as I go.
----
 
 ## Console Panel
 

--- a/posts/my-first-web-component-a-disclosure-widget.md
+++ b/posts/my-first-web-component-a-disclosure-widget.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 After a couple of years of reading about web components (and a lot of head-scratching), I’ve finally got around to properly creating one… or at least a rough first draft!
----
 
 [Check out disclosure-widget on codepen.](https://codepen.io/fuzzylogicx/pen/MWERKQo/?editors=1010)
 

--- a/posts/my-git-cheatsheet.md
+++ b/posts/my-git-cheatsheet.md
@@ -5,7 +5,6 @@ date: "2018-12-01T16:58:08.051Z"
 tags: [development, git, cheatsheet]
 ---
 I’ve used Git for many years but it can still trip me up. At times I’ve worked primarily in a GUI (like Sourcetree or Fork), and other times directly on the command line. I’ve worked on projects where I’ve been the sole developer and others where I’m part of a large team. Regardless of the tools or context, I’ve learned there are certain _need-to-knows_. Here’s a list of useful Git concepts and commands for my reference and yours.
----
 
 Note: the following is not an exhaustive list but rather the thing I keep coming back to and/or regularly forget. For deeper explanations, see the list of resources at the foot of the article.
 
@@ -30,7 +29,7 @@ Note: the following is not an exhaustive list but rather the thing I keep coming
 <details>
   <summary>Option 1: Create a new repo in your Github account</summary>
 
-This generates a new, empty repo (optionally initialised with a README). 
+This generates a new, empty repo (optionally initialised with a README).
 
 Do this when you will be working on a new, dedicated project rather than contributing changes to a pre-existing one.
 </details>
@@ -48,12 +47,12 @@ Github Reference: [Creating a repository from a template](https://help.github.co
 <details>
   <summary>Option 3: Fork an existing repo (usually owned by someone else)</summary>
 
-This generates a new repo which is a copy of another repo, including its commit history. Your commits will update your copy rather than the original repo. 
+This generates a new repo which is a copy of another repo, including its commit history. Your commits will update your copy rather than the original repo.
 
 Do this by clicking the _Fork_ button in the header of a repository.
 
 This is good for (often short-lived) collaboration on an existing repo. You can contribute code to someone else’s project, via PRs.
-   
+
 Github Reference: [Working with forks](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks)
 </details>
 
@@ -62,7 +61,7 @@ Github Reference: [Working with forks](https://help.github.com/en/github/collabo
 `clone` creates a _local copy_ on your computer of a remote (Github-hosted) repo.
 
 <figure>
-  
+
 ``` bash
 cd projects
 git clone https://github.com/githubusername/projectname.git optionallocaldirectoryname
@@ -72,7 +71,7 @@ git clone https://github.com/githubusername/projectname.git optionallocaldirecto
 
 You might be cloning a repo you own, or one owned by someone else (to use its features in your project).
 
-Your local copy will, by default, have its `origin` remote set to the Github repo you cloned. 
+Your local copy will, by default, have its `origin` remote set to the Github repo you cloned.
 
 <details>
   <summary>I cloned an empty new project</summary>
@@ -114,7 +113,7 @@ We’re in easy streets. The default remote is set exactly as you want it. Just 
 
   </figure>
   </details>
-  
+
   <details>
     <summary>The source repo is my fork of a project to which I want to contribute</summary>
 
@@ -132,7 +131,7 @@ This is a special type of clone. I know this is an option, but it‘s not one I�
 
 Although cloning is the easiest way to get started locally, ocassionally I start by coding from scratch instead.
 
-<figure>  
+<figure>
 
 ``` bash
 mkdir myproject && cd myproject
@@ -157,29 +156,29 @@ git push -u origin master
 Remove a remote from your local settings:
 
 <figure>
-  
+
 ``` bash
 git remote rm <name>
 ```
 
 </figure>
-  
+
 Rename a remote:
 
 <figure>
-  
+
 ``` bash
 git remote rename oldname newname
 ```
 
 </figure>
-  
+
 ## Configuration
 
 Configure your favourite editor to be used for commit messages:
 
 <figure>
-  
+
 ``` bash
 git config --global core.editor "nano"
 ```
@@ -189,7 +188,7 @@ git config --global core.editor "nano"
 Use `git st` as a shortcut for `git status` (to stop me mistyping as “statsu”):
 
 <figure>
-  
+
 ``` bash
 git config --global alias.st status
 ```
@@ -199,10 +198,10 @@ git config --global alias.st status
 Configure any setting:
 
 <figure>
-  
+
 ``` bash
 git config [--global] <key> <value>
-  
+
 git config --global user.email "myname@domain.com"
 ```
 
@@ -211,7 +210,7 @@ git config --global user.email "myname@domain.com"
 ## Staging, unstaging and deleting files
 
 <figure>
-  
+
 ``` bash
 # stage all unstaged files
 git add .
@@ -221,11 +220,11 @@ git add filename.txt
 ```
 
 </figure>
-  
+
 Unstage with `reset` (the opposite of `git add`):
 
 <figure>
-  
+
 ``` bash
 # unstage all staged files
 git reset .
@@ -235,65 +234,65 @@ git reset filename.txt
 ```
 
 </figure>
-  
+
 Delete a physical file and stage the deletion for the next commit:
 
 <figure>
-  
+
 ``` bash
 git rm folder/filename.txt
 ```
 
 </figure>
-  
+
 ## Committing updates
 
 Commit with [a multi-line message](https://thoughtbot.com/blog/5-useful-tips-for-a-better-commit-message):
 
 <figure>
-  
+
 ``` bash
 git commit
 ```
 
 </figure>
-  
+
 Commit with short message:
 
 <figure>
-  
+
 ``` bash
 git commit -m "fix: typo in heading"
 ```
 
 </figure>
-  
+
 Stage and commit all changes in a single command (note: doesn’t work with new, untracked files):
 
 <figure>
-  
+
 ``` bash
 git commit -am "fix: typo in heading"
 ```
 
 </figure>
-  
+
 ## Branches
 
 Show all local branches:
 
 <figure>
-  
+
 ``` bash
 git branch
 ```
 
 </figure>
-  
+
 Show all local _and remote_ branches:
 
 <figure>
-  
+
 ``` bash
 git branch -a
 ```
@@ -309,43 +308,43 @@ git branch --sort=-committerdate
 ```
 
 </figure>
-  
+
 Save current state to new branch but don’t yet switch to it (useful after committing to wrong branch):
 
 <figure>
-  
+
 ``` bash
 git branch newbranchname
 ```
 
 </figure>
-  
-Create and switch to new branch (`main` or whatever branch you want to branch off): 
+
+Create and switch to new branch (`main` or whatever branch you want to branch off):
 
 <figure>
-  
+
 ``` bash
 git checkout -b mynewbranch
 ```
 
 </figure>
-  
+
 Note that if you branch off `foo_feature` then when creating a PR in GitHub for your changes in `mynewbranch` you can change the _Base_ branch from the default of `main` to `foo_feature`. This specifies that you are requesting your changes be merged into `foo_feature` rather than `main` and makes the comparison of changes relative to `foo_feature` rather than `main`.
-   
+
 Switch to an existing branch:
 
 <figure>
-  
+
 ``` bash
 git checkout branchname
 ```
 
 </figure>
-  
+
 Save typing by setting the upstream remote branch for your local branch:
 
 <figure>
-  
+
 ``` bash
 # git branch -u remotename/branchname
 git branch -u fuzzylogic/v3
@@ -359,7 +358,7 @@ git pull
 Delete local branch:
 
 <figure>
-  
+
 ``` bash
 git branch -d name_of_branch
 
@@ -368,7 +367,7 @@ git branch -D name_of_branch
 ```
 
 </figure>
-  
+
 ## Save changes temporarily
 
 `stash` is like a clipboard for git.
@@ -386,11 +385,11 @@ git stash pop
 </figure>
 
 ## Staying current and compatible
-  
+
 `fetch` remote branch and `merge` simultaneously:
 
 <figure>
-  
+
 ``` bash
 git pull remotename branchname
 
@@ -412,7 +411,7 @@ git reset --hard origin/master
 Merge another branch (e.g. master) into current branch:
 
 <figure>
-  
+
 ``` bash
 git merge otherbranch
 
@@ -421,7 +420,7 @@ git merge master
 ```
 
 </figure>
-  
+
 ### Rebasing
 
 `git rebase` can be used as:
@@ -441,7 +440,7 @@ While it’s a good idea to `rebase` _before_ making a <abbr title="Pull Request
 Rebuild your feature branch’s changes on top of master:
 
 <figure>
-  
+
 ``` bash
 git checkout master
 git pull origin master
@@ -450,21 +449,21 @@ git rebase master
 ```
 
 </figure>
-  
+
 Force push your rebased branch (again, only when you’re unlikely to have/require collaborators on the PR):
 
 <figure>
-  
+
 ``` bash
 git push --force origin myfeaturebranch
 ```
 
 </figure>
-  
+
 Tidy a feature branch before making a PR:
 
 <figure>
-  
+
 ``` bash
 git checkout myfeaturebranch
 git rebase -i master
@@ -481,28 +480,28 @@ pick 5c67e61 Message for commit #3
 pick 33d5b7a Message for commit #1
 fixup 9480b3d Message for commit #2
 pick 5c67e61 Message for commit #3
-  
-# alternatively if use 'squash', after saving it will open an editor 
+
+# alternatively if use 'squash', after saving it will open an editor
 # and prompt you to set a new commit message for the combined stuff.
 pick 33d5b7a Message for commit #1
 squash 9480b3d Message for commit #2
 squash 5c67e61 Message for commit #3
 ```
-  
+
 [More on squash including a handly little video if I forget how it works.](https://www.git-tower.com/learn/git/faq/git-squash)
 
 </figure>
-  
+
 Undo a rebase:
 
 <figure>
-  
+
 ``` bash
 git reset --hard ORIG_HEAD
 ```
 
 </figure>
-  
+
 For more detail, read [Atlassian’s guide to rebasing](https://www.atlassian.com/git/tutorials/merging-vs-rebasing).
 
 ## Reviewing your activity
@@ -510,7 +509,7 @@ For more detail, read [Atlassian’s guide to rebasing](https://www.atlassian.co
 Show commit history (most recent first; `q` to quit):
 
 <figure>
-  
+
 ``` bash
 git log
 
@@ -522,11 +521,11 @@ git log branchname
 ```
 
 </figure>
-  
+
 Check if your feature branch is trailing behind:
 
 <figure>
-  
+
 ``` bash
 # show commits in master that are not yet in my feature branch
 git log --oneline my-feature..master
@@ -539,11 +538,11 @@ git log --author=Demaree --grep=heroku --oneline Gemfile
 ```
 
 </figure>
-  
+
 Show changes that occurred in the most recent commit or a given commit.
 
 <figure>
-  
+
 ```
 git show
 
@@ -556,17 +555,17 @@ git show 591672e
 Review differences between staged changes and last commit:
 
 <figure>
-  
+
 ``` bash
 git diff --cached
 ```
 
 </figure>
-  
+
 Review changes between a given version/commit and the latest:
 
 <figure>
-  
+
 ``` bash
 git diff 591672e..master
 ```
@@ -576,39 +575,39 @@ git diff 591672e..master
 ## Fixing Things
 
 Discard all your as-yet uncommitted changes:
-  
+
 <figure>
 
 ```bash
 git restore .
 ```
-  
+
 </figure>
-  
+
 Get your local feature branch out of a problem state by resetting to the state it is on the remote (e.g. at last `push`).
-  
+
 <figure>
 
 ```bash
 git reset --hard origin/my-branch
 ```
-  
+
 </figure>
-   
+
 Undo all the changes in a given commit:
 
 <figure>
-  
+
 ``` bash
 git revert 591672e
 ```
 
 </figure>
-  
+
 Alter the previous commit (change the message and/or include further updates):
 
 <figure>
-  
+
 ``` bash
 # we are amending the previous commit rather than creating a new commit.
 # if file changes are staged, it amends previous commit to include those.
@@ -617,11 +616,11 @@ git commit --amend
 ```
 
 </figure>
-  
+
 Move current branch tip backward to a given commit, reset the staging area to match, but leave the working directory alone:
 
 <figure>
-  
+
 ``` bash
 git reset 591672e
 
@@ -630,13 +629,13 @@ git reset --hard 591672e
 ```
 
 </figure>
-  
+
 See what the app/site was like (e.g. whether things worked or were broken) at a given previous commit, noting the following:
 - You’re now “detatched”, in that your computer’s HEAD is pointing at a commit rather than a branch.
 - You’re expected to merely review, not to make commits. Any commits you make would be “homeless”, since commits are supposed to go in branches. (However you could then branch off.)
 
 <figure>
-  
+
 ``` bash
 git checkout 591672e
 ```
@@ -646,7 +645,7 @@ git checkout 591672e
 Return one or more files to the state they were in at a previous commit, without reverting everything else.
 
 <figure>
-  
+
 ``` bash
 git checkout 3aa647dac9a8a251ca223a693d4c140fd3c1db11 /path/to/file.md /path/to/file2.erb
 
@@ -655,25 +654,25 @@ git commit
 ```
 
 </figure>
-  
+
 When `git st` reveals a list of staged files including lots of strange files you don’t want there mixed with others you do…
-  
+
 <figure>
-  
+
 ``` bash
 # add those you want to stay modified and staged
-git add path/to/file-I-want-1.rb path/to/file-I-want-2.md 
+git add path/to/file-I-want-1.rb path/to/file-I-want-2.md
 
 # this will clear all others out of the stage
 git checkout .
 ```
 
 </figure>
-  
+
 Grab one or more commits from elsewhere and drop into your current branch:
 
 <figure>
-  
+
 ``` bash
 git cherry-pick 591672e
 
@@ -682,11 +681,11 @@ git cherry-pick master
 ```
 
 </figure>
-  
+
 Fix a pull that went wrong / shouldn’t have been done:
 
 <figure>
-  
+
 ``` bash
 git pull origin branchname
 # whoops!
@@ -708,7 +707,7 @@ git reset HEAD@{index}
 Revert to the previous branch you were on
 
 <figure>
-  
+
 ``` bash
 git checkout -
 ```
@@ -716,7 +715,7 @@ git checkout -
 </figure>
 
 ## Useful GitHub stuff
-  
+
 - [Review your branches on a repo](https://github.com/[user]/[repo]/branches/yours)
 - [Review PRs and issues you’re subscribed to](https://github.com/notifications/subscriptions), i.e. ones on which you were active or mentioned
 - [Review your or another user’s PRs](https://github.com/pulls?q=is%3Apr+author%3Afuzzylogicxx+archived%3Afalse+)

--- a/posts/my-new-syntax-for-responsive-and-modern-blog-images.md
+++ b/posts/my-new-syntax-for-responsive-and-modern-blog-images.md
@@ -28,7 +28,6 @@ draft: false
 ---
 I’ve started trialling different HTML and technologies for the “simple” responsive images (i.e. not art-directed per breakpoint) used in blog articles on this site. I’m continuing to lean on Cloudinary as my free image host, CDN and format-conversion service. But at the HTML level I’ve moved from a complicated `<img srcset>` based approach that includes many resized versions of the same image. I now use a simpler `<picture>` and `<source>` based pattern that keeps the number of images and breakpoints low and instead – by using the source element’s `type` attribute – takes advantage of the performance gains offered by the new `avif` and `webp` image formats.
 
----
 
 My new approach is based on advice in Jake Archibald’s brilliant article [Halve the size of images by optimising for high density displays](https://jakearchibald.com/2021/serving-sharp-images-to-high-density-screens/). Jake explains that the majority of your traffic likely consists of users with high density screens so when we can combine optimising for that and making performance gains in a progressively enhanced way, we should! 
 

--- a/posts/my-ruby-and-rails-cheatsheet.md
+++ b/posts/my-ruby-and-rails-cheatsheet.md
@@ -12,7 +12,6 @@ tags:
   - cheatsheet
 ---
 I’m no Ruby engineer however even as a front-end developer I’m sometimes called upon to work on [Rails](https://rubyonrails.org/) applications that require me to know my way around. Here are my notes and reminders.
----
 
 This is not intended to be an authoritative guide but merely my notes from various lessons. It’s also a work-in-progress and a living, changing document.
 

--- a/posts/my-screen-reader-cheatsheet.md
+++ b/posts/my-screen-reader-cheatsheet.md
@@ -5,7 +5,6 @@ date: "2020-12-02T15:58:08.051Z"
 tags: [entry, development, cheatsheet, a11y, tool, voiceover]
 ---
 Here’s a list of useful Screen Reader commands and tips for my reference and yours. This is a work in progress and I’ll update it as I go.
----
 
 ## VoiceOver (Mac)
 

--- a/posts/my-vscode-cheatsheet.md
+++ b/posts/my-vscode-cheatsheet.md
@@ -5,7 +5,6 @@ date: "2020-02-24T09:58:08.051Z"
 tags: [development, editor, cheatsheet, vscode, tool, emmet, autocomplete]
 ---
 Here’s a list of useful (Mac-based) VS Code tips for my reference and yours.
----
 
 ## Use the Command Palette
 

--- a/posts/native-css-nesting.md
+++ b/posts/native-css-nesting.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 I’ve started reading some entries from Manuel Matuzovic’s [100 days of (more or less) modern CSS](https://www.matuzo.at/blog/2022/100-days-of-more-or-less-modern-css/) series, and began with the excellent [Day 99: Native Nesting](https://www.matuzo.at/blog/2023/100daysof-day99/). It clearly explains how to use the [now-agreed syntax](https://webkit.org/blog/13813/try-css-nesting-today-in-safari-technology-preview/) for various common scenarios.
----
 
 The syntax is pretty close to what we’re used to doing with Sass, which is great! 
 

--- a/posts/native-lazy-loading-for-the-web.md
+++ b/posts/native-lazy-loading-for-the-web.md
@@ -13,7 +13,6 @@ tags:
 linkTarget: https://web.dev/native-lazy-loading
 ---
 Now that we have the HTML attribute `loading` we can set `loading="lazy"` on our website’s media, and the loading of non-critical, _below-the-fold_ media will be deferred until the user scrolls to them.
----
 
 This can really improve performance so I’ve implemented it on images and iframes (youtube video embeds etc) throughout this site.
 

--- a/posts/nice-september-24.md
+++ b/posts/nice-september-24.md
@@ -13,7 +13,6 @@ tags:
 I now see why people love this part of the world. The dramatic coastline, beautiful deep blue Med, stunning buildings and balconies, incredible food scene, culture and history and buzz of activity… I could go on!
 
 Here’s a list of some noteworthy things we did and places we visited on this amazing holiday.
----
 
 ## Nice
 

--- a/posts/nordhealth-s-design-system.md
+++ b/posts/nordhealth-s-design-system.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 There’s so much to admire in Nord Health’s Design System and specifically its reference website.
----
 
 I love the way it looks and is organised.
 

--- a/posts/northumberland_trip.md
+++ b/posts/northumberland_trip.md
@@ -18,7 +18,6 @@ tags:
 - rudy
 ---
 Prior to Christmas we’d been talking about giving ourselves the present of a trip to London. However the train prices were pretty offensive so we opted for a different type of weekend trip – one that was rural, cosy and Rudy-friendly.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/number-and-date-inputs.md
+++ b/posts/number-and-date-inputs.md
@@ -13,7 +13,6 @@ noteWithTitle: true
 draft: false
 ---
 When asking users for numbers and dates, which HTML form elements should we use?
----
 
 When asking the user for numeric information it might feel obvious to use the HTML input type meant for that purpose, namely [number](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number). 
 

--- a/posts/observer-apis-in-a-nutshell.md
+++ b/posts/observer-apis-in-a-nutshell.md
@@ -15,7 +15,6 @@ tags:
 draft: false
 ---
 I’ve played with the various HTML5 Observer APIs (`IntersectionObserver`, `ResizeObserver` and `MutationObserver`) a little over the last few years—for example using `ResizeObserver` in a container query solution for responsive grids. But in all honesty their roles, abilities and differences haven’t yet fully _stuck_ in my brain. So I’ve put together a brief explainer for future reference. 
----
 
 ## Intersection Observer
 

--- a/posts/origami.md
+++ b/posts/origami.md
@@ -8,6 +8,5 @@ tags:
 linkTarget: https://origami-for-everyone.ft.com/about/measuring-success/#secondary-metrics-1
 ---
 The FT’s design system _Origami_ not only has a cool name but also some interesting metrics. 
----
 
 > Community engagement: We are measuring how many people attend our design system guild meetings. While not a goal in itself, we need an engaged community to help us make the right decisions, and an engaged community is also a sign that we’re solving problems that people want solved!

--- a/posts/pasta-alla-norma.md
+++ b/posts/pasta-alla-norma.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 This recipe from Gousto, with a few tweaks from Clair, is a straight winner. Although I’m sure it’s delicious as they list it, Clair substituted linguine for rigatoni and as a treat added some [artichoke hearts](https://www.waitrose.com/ecom/products/waitrose-sliced-artichoke-hearts/017483-8480-8481) which took it to the next level.
----
 
 Delicious, and a perfect example of a vegetarian meal where I didn’t miss meat at all.
 

--- a/posts/pitchfork-review-mills-liquid-room.md
+++ b/posts/pitchfork-review-mills-liquid-room.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 Pitchfork’s review of Jeff Mills’ seminal mixtape is the best-written and most enjoyable music article I’ve read in years. The mixtape in question is also very close to my heart.
----
 
 > this is a mix without equal, the Techno Bible, unequivocally The One.
 

--- a/posts/polypane-the-browser-for-responsive-web-development-and-design.md
+++ b/posts/polypane-the-browser-for-responsive-web-development-and-design.md
@@ -21,6 +21,5 @@ draft: false
 
 ---
 Polypane is a browser built specifically for developing responsive websites. It can present typical device resolutions side-by-side (for example iphone SE next to iphone 7 next to iPad) but also has some nice features such as automatically creating views based on your stylesheet’s media query breakpoints.
----
 
 It’s a subscription service and at the moment I’m happy using a combination of Firefox Nightly and Chrome so I think I’ll wait this one out for the time being. But I’ll be keeping my eye on it!

--- a/posts/poverty-safari-by-darren-mcgarvey.md
+++ b/posts/poverty-safari-by-darren-mcgarvey.md
@@ -9,5 +9,4 @@ description:
 draft: true
 ---
 Content to follow.
----
 

--- a/posts/practical-performance-tips.md
+++ b/posts/practical-performance-tips.md
@@ -12,7 +12,6 @@ tags:
 - performance
 ---
 I’ve been really interested in the subject of Web Performance since I read Steve Souders’ book _High Performance Websites_ back in 2007. Although some of the principles in that book are still relevant, it’s also fair to say that a lot has changed since then so I decided to pull together some current tips. Disclaimer: This is a living document which I’ll expand over time. Also: I’m a performance _enthusiast_ but not an expert. If I have anything wrong, please let me know.
----
 
 ## Inlining CSS and or JavaScript
 

--- a/posts/progressive-wordle-jehl.md
+++ b/posts/progressive-wordle-jehl.md
@@ -13,7 +13,6 @@ linkTarget: https://scottjehl.com/posts/wordleish/
 Scott proposes an interview question relating to web standards and intelligent use of JavaScript.
 
 > How would you attempt to build Wordle (...or some other complex app) if you could only use HTML and CSS? Which features of that app would make more sense to build with JavaScript than with other technologies? And, can you imagine a change or addition to the HTML or CSS standard that could make any of those features more straight-forward to build?
----
 
 > Discussing any approaches to this challenge will reveal the candidate's broad knowledge of web standards–including new and emerging HTML and CSS features–and as a huge benefit, it would help select for the type of folks who are best suited to lead us out of the JavaScript over-reliance problems that are holding back the web today.
 

--- a/posts/progressively-enhanced-burger-menu-tutorial-by-andy-bell.md
+++ b/posts/progressively-enhanced-burger-menu-tutorial-by-andy-bell.md
@@ -30,6 +30,5 @@ draft: false
 
 ---
 Here’s a smart and comprehensive tutorial from Andy Bell on how to create a progressively enhanced narrow-screen navigation solution using a custom element. Andy also uses `Proxy` for “enabled” and “open” state management, `ResizeObserver` on the custom element’s containing `header` for a Container Query like solution, and puts some serious effort into accessible focus management. 
----
 
 One thing I found really interesting was that Andy was able to style child elements of the custom element (as opposed to just elements which were present in the original unenhanced markup) from his global CSS. My understanding is that you can’t get styles other than inheritable properties through the _Shadow Boundary_ so this had me scratching my head. I think the explanation is that Andy is not attaching the elements he creates in JavaScript to the Shadow DOM but rather rewriting and re-rendering the element’s `innerHTML`. This is an interesting approach and solution for getting around web component styling issues. I see elsewhere online that [the `innerHTML` based approach is frowned upon](https://developers.google.com/web/fundamentals/web-components/customelements#addingmarkup) however Andy doesn’t “throw out” the original markup but instead augments it.

--- a/posts/progressively-enhanced-javascript-in-real-life.md
+++ b/posts/progressively-enhanced-javascript-in-real-life.md
@@ -12,7 +12,6 @@ tags:
   - accessibility
 ---
 Over the last couple of days I’ve witnessed a good example of progressive enhancement “In Real Life”. And I think it’s good to log and share these validations of web development best practices when they happen so that their benefits can be seen as real rather than theoretical.
----
 
 A few days ago I noticed that the search function on [my website](https://fuzzylogic.me/) wasn’t working optimally. As usual, I’d click the navigation link “Search” then some JavaScript would reveal a search input and set keyboard focus to it, prompting me to enter a search term. Normally, the JavaScript would then “look ahead” as I type characters, searching the website for matching content and presenting (directly underneath) a list of search result links to choose from.
 

--- a/posts/progressively-enhanced-javascript-with-stimulus.md
+++ b/posts/progressively-enhanced-javascript-with-stimulus.md
@@ -5,7 +5,6 @@ date: 2019-10-24
 tags: [web, development, javascript, framework, progressiveenhancement, stimulus]
 ---
 I’m dipping my toes into [Stimulus](https://stimulusjs.org/handbook/introduction), the JavaScript micro-framework from Basecamp. Here are my initial thoughts.
----
 
 I immediately like the ethos of Stimulus.
 

--- a/posts/providing-additional-semantics-using-schema.org.md
+++ b/posts/providing-additional-semantics-using-schema.org.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 I’ve been using [schema.org](https://schema.org/) for a few years now, but haven’t yet logged any notes and usage advice. Schema.org gives websites a practical, structured data approach for communicating the meaning of their content in finer detail than they could with native HTML alone. Google etc can then parse this and use it in their interfaces to offer users a richer view of your data.
----
 
 Schema.org lets you pick from different types of _properties_ for describing your content, such as book, person, place or event. Alternatively a more generic article you might use _BlogPosting_.
 

--- a/posts/quick-circle-by-adam-argyle.md
+++ b/posts/quick-circle-by-adam-argyle.md
@@ -12,7 +12,6 @@ draft: false
 
 ---
 I’m wary of list-based clickbait – and Adam’s recent [6 CSS snippets every front-end developer should know in 2023](https://web.dev/6-css-snippets-every-front-end-developer-should-know-in-2023) feels like that – however I like this modern and minimal approach to creating a circle. I’ve previously seen `aspect-ratio: 1` used to create a square box and it’s a lovely shorthand for “make width and height equal”. It makes sense that you can use it for a circle too, just by adding some `border-radius`.
----
 
     .circle {
       inline-size: 25ch;

--- a/posts/real-favicon-generator.md
+++ b/posts/real-favicon-generator.md
@@ -17,6 +17,5 @@ linkTarget: https://realfavicongenerator.net/
 
 ---
 Knowing how best to serve, size and format favicons and other icons for the many different device types and operating systems can be a minefield. My current best practice approach is to create a 260px × 260px (or larger) source icon then upload it to [Real Favicon Generator](https://realfavicongenerator.net/).
----
 
 This is the tool [recommended by CSS-Tricks](https://css-tricks.com/favicon-quiz) and it takes care of most of the pain by not only generating all the formats and sizes you need but also providing some code to put in your `<head>` and `manifest.webmanifest` file.

--- a/posts/recently-read-klara-and-the-sun.md
+++ b/posts/recently-read-klara-and-the-sun.md
@@ -1,10 +1,11 @@
 ---
 title: "Recently read: Klara and the Sun"
 description: I circled back to Kazuo’s Ishiguro’s latest novel having not had
-  the appetite for it during the pandemic and was glad I did
+  the appetite for it during the pandemic, and loved it.
 noteWithTitle: true
 date: 2025-06-22T16:23
 tags:
+  - note
   - book
   - technology
   - AI

--- a/posts/recipes.md
+++ b/posts/recipes.md
@@ -9,7 +9,6 @@ tags:
 draft: true
 ---
 …
----
 
 https://www.gousto.co.uk/cookbook/fish-recipes/10-min-chilli-garlic-jumbo-prawn-spaghetti
 

--- a/posts/refactoring-a-modal-dialogue-in-2022.md
+++ b/posts/refactoring-a-modal-dialogue-in-2022.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 My team will soon be refactoring our modal dialogue component. Ours has a few deficiencies, needs better developer experience and documentation, is not built to our Design System component standards, and could use a resilience boost from some progressive enhancement.
----
 
 For a long time the best – meaning accessible, framework-agnostic, feature-packed – modal implementations were _custom_. Specifically:
 

--- a/posts/relearn-css-layout-every-layout.md
+++ b/posts/relearn-css-layout-every-layout.md
@@ -18,7 +18,6 @@ linkTarget: ''
 
 ---
 Every now and then something comes along in the world of web design that represents a substantial shift. The launch of [Every Layout](https://every-layout.dev/), a new project from Heydon Pickering and Andy Bell, feels like one such moment.
----
 
 In simple terms, we get a bunch of responsive layout utilities: a Box, a Stack, a Sidebar layout and so on. However Every Layout offers so much more—in fact for me it has provided whole new ways of thinking and talking about modern web development. In that sense I’m starting to regard it in terms of classic, game-changing books like [Responsive Web Design](https://abookapart.com/products/responsive-web-design) and [Mobile First](https://abookapart.com/products/mobile-first).
 

--- a/posts/releasing-early-releasing-often-and-avoiding-paralysis-by-analysis.md
+++ b/posts/releasing-early-releasing-often-and-avoiding-paralysis-by-analysis.md
@@ -5,7 +5,6 @@ description: Getting Things Done requires keeping the perfectionist urges at bay
 tags: [entry, personal, mvp, progressiveenhancement]
 ---
 My name is Laurence Hughes and I’m a perfectionist. But I’m working on it.
----
 
 I’ve suffered from the painful affliction of perfectionism for as long as I can remember (I blame the mother…) and although I’m much better than I used to be, I don’t think it ever fully leaves you.
 

--- a/posts/remembering-a-night-at-tresor.md
+++ b/posts/remembering-a-night-at-tresor.md
@@ -13,7 +13,6 @@ noteWithTitle: true
 draft: false
 ---
 I was recently sorting through some old stuff when I found a tatty old poster I used to love and that brought back good memories. It shows the [gated basement vault of the original Tresor nightclub](https://bldgblog.com/wp-content/uploads/2007/01/368327890_ce3550f954_o.jpg) at Potsdamer Platz, Berlin. Smoke is billowing out of the room dramatically and it includes the text _The Extremist_. I bought or otherwise acquired this poster on a night in 2005 when me and friends Davie and Tom visited the famous club during a trip to Berlin.
----
 
 That was a great trip. While Davie wasn’t in the best of health at the time, we still got up to a variety of high jinks, including a memorable drinking session with techno legend [Dan Curtin](https://www.discogs.com/artist/3402-Dan-Curtin) who was releasing music on Tom’s label at the time. (I think that was my introduction to strong Belgian beer, and I remember being mightily impressed when Dan cycled off at the end.) I also remember we stayed in Prenzlauer Berg, at [Transit Loft](https://www.transit-loft.de/?lang=en) if I recall rightly.
 

--- a/posts/replicating-jekylls-markdownify-filter-in-nunjucks-with-eleventy.md
+++ b/posts/replicating-jekylls-markdownify-filter-in-nunjucks-with-eleventy.md
@@ -12,7 +12,6 @@ tags:
 linkTarget: https://edjohnsonwilliams.co.uk/2019/05/04/replicating-jekyll-s-markdownify-filter-in-nunjucks-with-eleventy/
 ---
 Here, [Ed](https://edjohnsonwilliams.co.uk/) provides some handy code to convert a Markdown-formatted string into HTML in Nunjucks via an Eleventy shortcode.
----
 
 This performs the same role as the [_markdownify_ filter in Jekyll](https://jekyllrb.com/docs/liquid/filters/).
 

--- a/posts/resources-for-learning-front-end-web-development.md
+++ b/posts/resources-for-learning-front-end-web-development.md
@@ -26,7 +26,6 @@ draft: false
 A designer colleague recently asked me what course or resources I would recommend for learning front-end web development. She mentioned React at the beginning but I suggested that it’d be better to start by learning HTML, CSS, and JavaScript. As for React: it’s a subset or offshoot of JavaScript so it makes sense to understand vanilla JS first.
 
 For future reference, here are my tips.
----
 
 ## Everything in one place
 

--- a/posts/resources-for-special-typographic-characters.md
+++ b/posts/resources-for-special-typographic-characters.md
@@ -17,7 +17,6 @@ tags:
 draft: false
 ---
 A collection of resources for finding that curly quote or em dash character quickly.
----
 
 [Smart quotes for smart people](http://smartquotesforsmartpeople.com/)
 

--- a/posts/responsive-navigation-round-up.md
+++ b/posts/responsive-navigation-round-up.md
@@ -15,7 +15,6 @@ The challenge is twofold:
 
 1. provide responsive navigation that’s effective on multiple viewport sizes, and 
 2. ensure that it’s resilient.
----
 
 ## BBC (footer nav, duplication, and PE)
 

--- a/posts/reusable-code-snippets-and-components-in-eleventy.md
+++ b/posts/reusable-code-snippets-and-components-in-eleventy.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 There are (at least) three cunning ways in Eleventy to get “reusable snippet” or “reusable component” functionality.
----
 
 1. Nunjucks’s `include`:  Great for just including a common, static element in your template, say a `header` or `footer` partial. (Note that while you _can_ `set` a variable just before your `include` line to make that variable available to the included partial, it’s not really “passing in” and scoping the variable like a parameter, so it’s best to reserve `include` for simple stuff.)
 2. Nunjucks’s `macro`:  Takes things up a notch by supporting passing in parameters which are then locally scoped. You could use this to create a simple component. See Trys Mudford’s article [Encapsulated 11ty Components](https://www.trysmudford.com/blog/encapsulated-11ty-components/).

--- a/posts/right-here-right-now.md
+++ b/posts/right-here-right-now.md
@@ -8,6 +8,5 @@ tags:
 linkTarget: https://www.martingunnarsson.com/posts/right-here-right-now/
 ---
 Martin introduces the “Now” page concept and how he adapted it for showing on his homepage. 
----
 
 I quite like the _Now_ concept in general and have already starting tinkering with it. I also really like Martin’s neat, _front matter-free_ solution in Eleventy (single config file plus date-oriented filenames) and could see that being more widely reusable for me for other “light-touch, non-page collections”.

--- a/posts/rip-kerso.md
+++ b/posts/rip-kerso.md
@@ -15,7 +15,6 @@ location: Antibes, France
 ---
 On Saturday my friend Mick called to give me the shock news that our mutual friend, Kerso (Graham) had passed away. I’ve known Kerso for around 26 years, since I worked in Bomba records. He was a force of nature, a generous soul, a good guy. I and all his friends loved him.
 
----
 
 Some of my favourite Kerso memories include him bounding into the shops where I worked (either Bomba or later Sound Control) on a Saturday afternoon, big broad smile and dressed immaculately, embodying the feeling that the weekend had landed. Or at club nights and parties or when he was on the decks, always a bundle of energy and a blur of hair! There was the time he bought me a signed copy of Neil Lennon’s biography for my birthday, having queued to get Lenny’s signature despite not being a fan himself (to put it lightly) but because he knew I’d love the gift. Then there’s his 40th birthday do at the Sub Club, a legendary party and where Clair and I met. I could go on, and on.
 

--- a/posts/rise-by-gina-miller.md
+++ b/posts/rise-by-gina-miller.md
@@ -17,7 +17,6 @@ draft: false
 
 ---
 I’ve just read _Rise_ by Gina Miller.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/roselli-underline-links.md
+++ b/posts/roselli-underline-links.md
@@ -10,7 +10,6 @@ tags:
 linkTarget: https://adrianroselli.com/2016/06/on-link-underlines.html 
 ---
 Adrian [recommends](https://adrianroselli.com/2016/06/on-link-underlines.html#recommendation) that we underline links in body copy and provides a host of evidence and rationale to back that up.
----
 
 > WCAG guidelines tell us to make sure we do not rely on color alone to distinguish links and even explicitly suggest underlines.
 

--- a/posts/rubadub-app.md
+++ b/posts/rubadub-app.md
@@ -6,7 +6,6 @@ tags: [link, app, development, greenhill, work, vinyl, records, recommendations]
 linkTarget: https://www.rubadub.co.uk/rubadub-app/
 ---
 [Rubadub](https://www.rubadub.co.uk/) have a new mobile app that delivers the RaD crew’s top vinyl recommendations (the best around) direct to your phone.
----
 
 At a time when lots of vinyl releases are highly limited, this gets you early access to the latest heat before it disappears. It should also generally save untold hours browsing/searching since in their recommendations Rubadub have already done the job of separating the wheat from the chaff.
 

--- a/posts/saas-startups-will-have-to-care-about-productivity-again-by-dhh.md
+++ b/posts/saas-startups-will-have-to-care-about-productivity-again-by-dhh.md
@@ -26,6 +26,5 @@ DHH of 37 Signals and Basecamp offers three pieces of advice for productivity an
   <p>3: Hire designers who work natively with the web.</p>
 </blockquote>
 
----
 
 I’m not a fan of the term “full-stack” and also think it underestimates the complexity/speciality required to work (properly) as a front-end developer. However that aside, I think there is sense in these, even though others I know would disagree.

--- a/posts/saving-css-changes-in-devtools-without-leaving-the-browser.md
+++ b/posts/saving-css-changes-in-devtools-without-leaving-the-browser.md
@@ -29,7 +29,6 @@ draft: false
 > Browser devtools have made redesigning a site such a pleasure. I love writing and adjusting a CSS file right in the sources panel and seeing design changes happen as I type, and saving it back to the file. (…) Designing against live HTML allows happy accidents and discoveries to happen that I wouldn't think of in an unconstrained design mockup
 
 I feel very late to the party here. I tend to tinker in the DevTools Element Styles panel rather than save changes. So, inspired by Scott, I’ve just tried this out on my personal website. Here’s what I did.
----
 
 1. started up my 11ty-based site locally which launches a `localhost` URL for viewing it in the browser;
 2. opened Chrome’s DevTools at _Sources;_

--- a/posts/saying-bye-bye-to-autoprefixer.md
+++ b/posts/saying-bye-bye-to-autoprefixer.md
@@ -15,7 +15,6 @@ tags:
 draft: false
 ---
 For a while now I’ve been using [gulp-autoprefixer](https://www.npmjs.com/package/gulp-autoprefixer) as part of my front-end build system. However, I’ve just removed it from my boilerplate. Here’s why.
----
 
 The npm module `gulp-autoprefixer` takes your standard CSS then automatically parses the rules and generates any necessary vendor-prefixed versions, such as `::-webkit-input-placeholder` to patch support for `::placeholder` in older Webkit browsers.
 

--- a/posts/secrets-to-block-like-a-pro-pech-pong.md
+++ b/posts/secrets-to-block-like-a-pro-pech-pong.md
@@ -25,7 +25,6 @@ In this tutorial video Seth Pech shares what he’s learned about that most foun
 <div class="l-frame">
   <iframe title="Pech Pong’s secrets to block like a pro tutorial" width="560" height="315" src="https://www.youtube.com/embed/J0tdMgyyCpE" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
----
 
 Fundamentals:
 

--- a/posts/semantic-commit-messages.md
+++ b/posts/semantic-commit-messages.md
@@ -10,7 +10,6 @@ tags:
 linkTarget: https://seesparkbox.com/foundry/semantic_commit_messages
 ---
 A fairly rigid commit format (`chore`, `fix`, `feat` etc) which should lead to your git log being an easy-to-skim changelog.
----
 
 I’d noticed that my git commit messages could benefit from greater consistency. So I’ve started adopting Sparkbox’s approach.
 

--- a/posts/sets-in-javascript.md
+++ b/posts/sets-in-javascript.md
@@ -10,7 +10,6 @@ draft: false
 ---
 I don’t often store things in a `Set` in JavaScript, but maybe I should. The fact it will only store *unique values* makes it pretty handy.
 
----
 
 One place I do currently use a `Set` is for the `TagList` in my 11ty-based personal website. I start by defining `TagList` as a new, empty `Set`. I then need to assemble all possible tags so iterate blog posts and for each add its associated tags to `TagList`. This means I can be sure that all duplicates will be removed automatically.
 

--- a/posts/shadeed-container-queries.md
+++ b/posts/shadeed-container-queries.md
@@ -12,6 +12,5 @@ linkTarget: https://ishadeed.com/article/css-container-query-guide/
 This is a wonderful guide that’s choc-full of practical examples.
 
 > CSS container queries help us to write a truly fluid components that change based on their container size. In the next few years, we’ll see less media queries and more container queries.
----
 
 Lots of inspiration here for when I start using Container Queries in earnest.

--- a/posts/should-i-use-a-button-or-a-link.md
+++ b/posts/should-i-use-a-button-or-a-link.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 I’ve written previously about the [important differences between buttons and links](https://fuzzylogic.me/posts/buttons-versus-links-differences-and-tips/). While reviewing some “component refresh” design mocks at work yesterday I noticed the designs were a bit unclear in this regard so I sent the designers a little decision-tree, which I’m noting here for future reference.
----
 
 It’s important both for our users and for us as practitioners to distinguish between links (the `<a>` element) and the `<button>` element. The reason I push this is because they’re fundamentally different functionally, which has important usability implications. Users expect to use mouse, keyboard, browser back-button and assistive tech differently for links than they do for `<button>`s. And if they can’t visually distinguish one from the other, they’ll try things they expect to work then get confused when they don’t work.
 

--- a/posts/should-i-use-the-html-title-attribute.md
+++ b/posts/should-i-use-the-html-title-attribute.md
@@ -19,7 +19,6 @@ mainImage.isAnchor: false
 draft: false
 ---
 People have used the HTML title attribute to achieve a native “tooltip” effect for many years. However accessibility experts have recommended that we should avoid this practice, and here I summarise my research on the topic.
----
 
 Renowned accessibility solutions provider [The Paciello Group recommend the title attribute should almost always be avoided.](https://www.tpgi.com/using-the-html-title-attribute/) It causes problems for lots of different usage contexts (keyboard, touch device, screen readers). The only place where I can see that it is still helpful is on `iframe`. It _was_ beneficial on form inputs in cases where a visible text label would be redundant and we want to provide our control with a programmatically associated label, however we now have `aria` attributes which do a better job.
 

--- a/posts/should-i-use-the-html5-section-element-and-if-so-where.md
+++ b/posts/should-i-use-the-html5-section-element-and-if-so-where.md
@@ -25,7 +25,6 @@ draft: false
 
 ---
 Unlike other HTML5 elements such as `header`, `footer` and `nav`, it’s never been particularly clear to me when is appropriate to use `section`. This is due in large part to many experts having expressed that it doesn’t quite work as intended.
----
 
 I like [HTMHell’s rule-of-thumb regarding `section`](https://www.htmhell.dev/tips/the-section-element/):
 

--- a/posts/sicily-2023.md
+++ b/posts/sicily-2023.md
@@ -11,6 +11,5 @@ tags:
 draft: true
 ---
 Foo
----
 
 Bus tour https://www.getyourguide.com/palermo-l387/palermo-hop-on-hop-off-tour-24h-ticket-t50725/

--- a/posts/sketch-tips-and-tricks.md
+++ b/posts/sketch-tips-and-tricks.md
@@ -5,7 +5,6 @@ date: "2019-06-23T16:58:08.051Z"
 tags: [design, sketch, cheatsheet]
 ---
 Here’s a list of useful (Mac-based) Sketch tips for my reference and yours.
----
 
 ## Commands Quick Reference
 

--- a/posts/small-changes.md
+++ b/posts/small-changes.md
@@ -12,7 +12,6 @@ draft: false
 Growing up, I recall my Dad often used the old Scots phrase _mony a mickle maks a muckle_ and I’ve always loved it. It’s about the value of taking care of the little things because if you keep it up you get something bigger. 
 
 It’s true, and here’s a good example. Over the last six months I’ve made lots of small changes to my life and I’m feeling an overall benefit.
----
 
 ## Where I started
 

--- a/posts/small-victories.md
+++ b/posts/small-victories.md
@@ -9,7 +9,6 @@ tags:
 linkTarget: https://www.smallvictori.es/
 ---
 > No CMS, no installation, no server, no coding required.
----
 
 Another quick and clever way of creating a website; this time by collecting a bunch of files (HTML, video, images, bookmarks) into a folder, connecting Dropbox and _Small Victories_ to that, choosing a theme and Hey Presto, you have a website.
 

--- a/posts/southside-february-weekend.md
+++ b/posts/southside-february-weekend.md
@@ -15,7 +15,6 @@ draft: false
 
 ---
 Last weekend was pretty dull and rainy in Glasgow but Clair and I visited a bunch of great local places to keep the spirits up. 
----
 
 On Friday night we ate at [Wasabi](https://wasabiglasgow.co.uk/) for the first time. It’s a lovely little spot on Pollokshaws Road with a [nicely-sized menu](https://wasabiglasgow.co.uk/). Between us we had Chicken Karage, Avocado Maki, King Prawn Tempura and Beef Ramen. We loved it and will be back.
 

--- a/posts/specs-and-standards.md
+++ b/posts/specs-and-standards.md
@@ -12,7 +12,6 @@ draft: false
 Something Adrian Roselli said recently has stuck with me. The gist was that when developers need definitive guidance they shouldn’t treat MDN as gospel, but rather refer to the proper specifications for web standards.
 
 Note: this post is a work in progress. I’ll refine it over time.
----
 
 ## HTML
 [The HTML Living Standard](https://html.spec.whatwg.org/multipage/)

--- a/posts/stuffing-the-front-end.md
+++ b/posts/stuffing-the-front-end.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 Here’s Bridget Stewart, a developer from Ohio, with some thoroughly enjoyable “curmudgeonly” thoughts on why your website doesn’t necessarily need a Javascript framework.
----
 
 With websites taking a median time of 5.8 seconds to show primary content (source: HTTPArchive) and Google warning us that 53% of mobile visits leave pages that take longer than three seconds to load, it’s hard to justify stuffing the front-end unnecessarily.
 

--- a/posts/subgrid-for-css-grid-launches-in-firefox.md
+++ b/posts/subgrid-for-css-grid-launches-in-firefox.md
@@ -5,7 +5,6 @@ description: Subgrid for CSS Grid layout has arrived.
 tags: [development,css,cssgrid,layout]
 ---
 Subgrid for CSS Grid Layout has [arrived in Firefox](https://hacks.mozilla.org/2019/12/firefox-71-a-year-end-arrival/) and it looks great. Here’s how I wrapped my head around the new concepts.
----
 
 While MDN has [some nice examples](https://wiki.developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid), I generally find I need a little extra time, trial and error and note-making in order to fully grasp CSS Grid concepts. 
 

--- a/posts/sunday-dinner-ox-finch.md
+++ b/posts/sunday-dinner-ox-finch.md
@@ -19,10 +19,9 @@ draft: false
 
 ---
 My generous nieces and nephews clubbed together to give us the Christmas present of a voucher for [Ox and Finch](https://www.oxandfinch.com/). Keen to use it, we got together with James and Grant for a lovely Sunday dinner.
----
 
-It’s a “small plates” affair, so sharing is the order of the day. We had sourdough and butter (the bread in good restaurants is always amazing), whipped feta with honey, fried artichokes with garlic yoghurt, and – my two favourites – the crab tubetti and beef tartare. To drink I had a white wine – the ‘le campuget’ grenache viognier – then their _px old fashioned_ (the _px_ standing for pedro ximénez). 
+It’s a “small plates” affair, so sharing is the order of the day. We had sourdough and butter (the bread in good restaurants is always amazing), whipped feta with honey, fried artichokes with garlic yoghurt, and – my two favourites – the crab tubetti and beef tartare. To drink I had a white wine – the ‘le campuget’ grenache viognier – then their _px old fashioned_ (the _px_ standing for pedro ximénez).
 
-We also shared the warm ginger cake with poached pear, while James had the affogato. 
+We also shared the warm ginger cake with poached pear, while James had the affogato.
 
 It was fantastic and – thanks to that thoughful gift – didn’t cost us a penny. What a great Christmas present.

--- a/posts/super-reliable-forehand-topspin-technique.md
+++ b/posts/super-reliable-forehand-topspin-technique.md
@@ -27,7 +27,6 @@ I’ve always liked the idea of this shot – the archetypal third ball in the r
 <div class="l-frame">
   <iframe title="Emma Haradine’s super-reliable forehand loop technique" width="560" height="315" src="https://www.youtube.com/embed/XcS7ol2GP10" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 </div>
----
 
 The key points are:
 

--- a/posts/svg-collected-tips.md
+++ b/posts/svg-collected-tips.md
@@ -17,7 +17,6 @@ draft: false
 
 ---
 SVG is an amazing technology which I regularly use for icons and occasionally for logos and illustrations. I’ve also dipped my toe into animated SVG. But if I’m honest I still find some SVG concepts confusing so I’ve gathered some useful tips here for future reference. Note: this is a living document which I’ll expand over time.
----
 
 ## Table of contents
 

--- a/posts/svg-gobbler.md
+++ b/posts/svg-gobbler.md
@@ -23,6 +23,5 @@ draft: false
 
 ---
 > SVG Gobbler is a browser extension that finds the vector content on the page you’re viewing and gives you the option to download, optimize, copy, view the code, or export it as an image.
----
 
 This is a pretty handy Chrome extension that grabs all the SVGs on a webpage and lets you see them all in a grid.

--- a/posts/switching-to-serverless.md
+++ b/posts/switching-to-serverless.md
@@ -14,7 +14,6 @@ draft: true
 eleventyExcludeFromCollections: true
 ---
 SEe https://trello.com/c/DJOVkciy/87-write-and-publish-a-debrief-blog-post-i-got-help-from and "Notes > My Blog"
----
 
 From dynamic Perch and LAMP to static 11ty and Netlify
 Continuous deployment

--- a/posts/tables-and-pseudo-tables-lessons-and-tactics.md
+++ b/posts/tables-and-pseudo-tables-lessons-and-tactics.md
@@ -23,7 +23,6 @@ draft: false
 At work I have to think about complex HTML tables a lot. The challenge with doing tables well is that 99% of online table tutorials use fairly simple examples… whereas in reality design and product teams often want to squeeze in lots more. It’s really hard to balance those needs against accessibility, systemisation, styling and responsiveness. 
 
 Heads up: I’ve published this post early while it’s still a work in progress because it’s better for me to have it available for reference than languishing in drafts and forgotten. Apologies if you read it in a temporarily rough state.
----
 
 Following a lot of work on tables I’ve recently gained additional insight into the possibilities and constraints, thanks to an accessibility review by [Tetralogical](https://tetralogical.com/) and some great articles by [Adrian Roselli](https://adrianroselli.com/). 
 

--- a/posts/tabs-truth-fiction-and-practical-measures.md
+++ b/posts/tabs-truth-fiction-and-practical-measures.md
@@ -20,7 +20,6 @@ draft: false
 
 ---
 My colleague Anda and I just had a good conversation about tabs, and specifically the company’s tabs component. I’ve mentioned before that our tabs are unconventional and potentially confusing, and Anda was interested to hear more.
----
 
 ## What’s the purpose of a tabbed interface?
 

--- a/posts/teabag-on-spoon.md
+++ b/posts/teabag-on-spoon.md
@@ -14,7 +14,6 @@ draft: false
 At work today I mentioned Mr Scruff’s tip for quick tea-making. My teammates laughed and said they felt like they were on an episode of _Would I lie to you?_ I had to prove I wasn’t talking rubbish and went looking for the tip online. It has all but disappeared from the web but thanks to [Wayback Machine](https://archive.org/web/) I was able to find a cache of the page from 2007.
 
 So here is the tea-making tip, listed in full for posteri-tea! (Sorry…)
----
 
 Mr Scruff starts by saying:
 

--- a/posts/template-post-bookmark.md
+++ b/posts/template-post-bookmark.md
@@ -9,6 +9,5 @@ tags:
 linkTarget: https://www.bbc.co.uk/iplayer/episode/m001wtqp/the-rescue
 ---
 Foo
----
 
 Bar

--- a/posts/tenet-revisited.md
+++ b/posts/tenet-revisited.md
@@ -9,7 +9,6 @@ tags:
   - christophernolan
 ---
 I watched [Tenet](https://www.imdb.com/title/tt6723592/) again last night (in IMAX with [Jamie](@jamiethomsonno1)) and second time round it all made sense. 
----
 
 My initial viewing was good but really confusing; but this time I knew what was going on and loved it! Based on the plot, it actually makes sense that you need to see it twice, too. 
 

--- a/posts/testing-es-modules-with-jest.md
+++ b/posts/testing-es-modules-with-jest.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 Here are a few troubleshooting tips to enable Jest, the JavaScript testing framework, to be able to work with ES modules without needing Babel in the mix for transpilation. Let’s get going with a basic set-up.
----
 
 `package.json`
 

--- a/posts/the-accessibility-of-conditionally-revealed-questions-on-gov.uk.md
+++ b/posts/the-accessibility-of-conditionally-revealed-questions-on-gov.uk.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 Here’s something to keep in mind when designing and developing forms. [GOV.UK](http://gov.uk/)’s accessibility team found last year that there are some accessibility issues with the “conditional reveal” pattern, i.e. when selecting a particular radio button causes more inputs to be revealed.
----
 
 [The full background story](https://accessibility.blog.gov.uk/2021/09/21/an-update-on-the-accessibility-of-conditionally-revealed-questions/) is really interesting but the main headline seems to be: _Keep it simple._
 

--- a/posts/the-aria-presentation-role.md
+++ b/posts/the-aria-presentation-role.md
@@ -21,7 +21,6 @@ draft: false
 
 ---
 I’ve never properly understood when you would need to use the ARIA `presentation` role. This is perhaps in part because it is often used inappropriately, for example in situations where `aria-hidden` would be more appropriate. However I think the penny has finally dropped.
----
 
 It’s fairly nuanced stuff so I’ll forgive myself this time!
 

--- a/posts/the-art-of-djing-jeff-mills-on-resident-advisor.md
+++ b/posts/the-art-of-djing-jeff-mills-on-resident-advisor.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 Fair play, Jeff – once this interview gets going it’s pretty damn good.
----
 
 Amongst other ground, it covers:
 

--- a/posts/the-atkinson-hyperlegible-font-braille-institute.md
+++ b/posts/the-atkinson-hyperlegible-font-braille-institute.md
@@ -16,6 +16,5 @@ Braille Institute launch a new, free typeface promising greater legibility and r
 
 > What makes it different from traditional typography design is that it focuses on letterform distinction to increase character recognition, ultimately improving readability.
 
----
 
 via [@brucel](https://twitter.com/brucel)

--- a/posts/the-best-way-to-install-nodejs-and-npm-on-a-mac.md
+++ b/posts/the-best-way-to-install-nodejs-and-npm-on-a-mac.md
@@ -5,7 +5,6 @@ description: I’ve found that although the NodeJs website includes an installer
 tags: [web, development, nodejs, npm, homebrew, brew]
 ---
 In modern front-end development, we tend to use a number of JavaScript-based build tools (such as task runners like Gulp) which have been created using Node.js and which we install using NPM. Here’s the best way I’ve found for installing and maintaining Node and NPM on a Mac.
----
 
 To install and use NPM packages, we first need to install Node.js and NPM on our computer (in my case a Mac).
 

--- a/posts/the-fear-of-keeping-up.md
+++ b/posts/the-fear-of-keeping-up.md
@@ -23,7 +23,6 @@ draft: false
 Great post by Chris here on the double-edged-sword of our rapidly-evolving web standards, and how to stay sane. On the one hand the latest additions to the HTML, CSS and JavaScript standards are removing the need for many custom tools which is positive. However:
 
 > it can also leave you feeling like it’s impossible to keep up or learn it all. And that’s because you can’t! The field is literally too big to learn everything. “Keeping up” is both impossible and overrated. It’s the path to burnout.
----
 
 Chris’s suggestion – something I find reassuring and will return to in moments of doubt – is that we focus on:
 

--- a/posts/the-man-in-the-high-castle-by-philip-k-dick.md
+++ b/posts/the-man-in-the-high-castle-by-philip-k-dick.md
@@ -9,7 +9,6 @@ mainImage:
   figcaption: The Man in the High Castle by Philip K. Dick
 ---
 The second Phillp K Dick I’ve read this year is his alternative-history sci-fi classic.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/the-new-css-by-matthias-ott.md
+++ b/posts/the-new-css-by-matthias-ott.md
@@ -25,7 +25,6 @@ Matthias feels that the recent slew of additions to CSS have completely changed 
 > this time, something feels different… the changes coming to CSS are so fundamental on so many levels that it almost feels like a singularity. There is now the CSS before and the CSS after the early 2020s.
 
 > Want to emulate and confidently design a layout that leverages the potential of CSS Grid in any of the major design tools like Figma, Adobe XD, or Sketch? Not possible. Want to define a color in one of the wide gamut color spaces like OKLCH, which result in more vibrant and natural colors on modern screens, maybe by using a color picker? Not possible. You want to simulate fluid typography that dynamically scales font sizes based on the viewport or container size and also define minimum and maximum values like you can do it in CSS with clamp()? Not possible. Or how about defining a fallback font in case your web font doesn’t load? Good luck using any screen design tool on the market. Not only are all of those things – very clearly – important design decisions, but they are also easily possible with just a few lines of CSS. In this new era of CSS, the design tools are now the limiting factor.
----
 
 He also hopes and suggests that CSS might become more respected and teams might “shift left” with regard to prototyping in the browser.
 

--- a/posts/the-new-html-search-element.md
+++ b/posts/the-new-html-search-element.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 My work colleague [Ryan](https://twitter.com/ryandeegan) recently drew my attention to the new HTML `search` element. This morning I read [Scott O’Hara’s excellent primer](https://www.scottohara.me/blog/2023/03/24/search-element.html). Scott worked on implementing `<search>`, and his article cleared up my questions around what it is and when we can start using it.
----
 
 Firstly `<search>` is not a “search input” – it’s not a replacement for any existing `input` elements. Instead it’s a native HTML element to create a `search` [landmark](https://www.w3.org/TR/wai-aria-1.2/#landmark_roles), something that until now we could only achieve by applying `role="search"` to another element.
 

--- a/posts/the-only-accessibility-practitioner-in-the-room.md
+++ b/posts/the-only-accessibility-practitioner-in-the-room.md
@@ -19,7 +19,6 @@ draft: false
 
 ---
 Henny Swan, director at Tetralogical, with some great advice for those whom accessibility responsibility often falls to.
----
 
 Henny advises:
 

--- a/posts/the-rescue.md
+++ b/posts/the-rescue.md
@@ -10,6 +10,5 @@ tags:
 linkTarget: https://www.bbc.co.uk/iplayer/episode/m001wtqp/the-rescue
 ---
 This retelling of an incredible story featuring unbelievable examples of human skill, endurance and hope is the best TV programme I’ve watched in years.
----
 
 > Chronicling the story that transfixed the world in 2018 – the daring rescue of 12 boys and their coach from deep inside a flooded cave in northern Thailand. This film shines a light on the high-risk world of cave diving, the astounding courage and compassion of the rescuers and the shared humanity of an international community that united to save the boys.

--- a/posts/the-social-dilemma.md
+++ b/posts/the-social-dilemma.md
@@ -11,7 +11,6 @@ tags:
   - socialmedia
 ---
 I watched Netflix’s documentary [The Social Dilemma](https://www.netflix.com/gb/title/81254224) the other night. It’s been generating a bit of a buzz, and its subject matter – the effects of social media – is one I’m generally interested in. However, I wasn’t a fan.
----
 
 While I totally agree with the sentiment that Facebook and Google (amongst others) don’t act in our best interests, there were more than a few aspects of this film that didn’t sit quite right. 
 

--- a/posts/the-testament-of-gideon-mack-by-james-robertson.md
+++ b/posts/the-testament-of-gideon-mack-by-james-robertson.md
@@ -9,7 +9,6 @@ mainImage:
   figcaption: The Testament of Gideon Mack by James Robertson
 ---
 A strange, otherwordly and often pretty funny tale of a Scottish minister’s dance with The Devil.
----
 
 {% if app.environment == "production" %}
 <figure>

--- a/posts/the-web-is-supposed-to-be-accessible-to-all.md
+++ b/posts/the-web-is-supposed-to-be-accessible-to-all.md
@@ -8,7 +8,6 @@ linkTarget: "https://www.w3.org/WAI/fundamentals/accessibility-intro/"
 Working as a web developer, you’ll meet colleagues who don’t realise that **accessibility should be non-negotiable**. So I’m bookmarking for ready access Tim Berners-Lee’s oft-quoted but still powerful statement of intent from 1997.
 
 > The power of the Web is in its universality. Access by everyone regardless of disability is an essential aspect.
----
 
 This particular W3C WAI page goes on to say:
 

--- a/posts/this-week-i-used-an-accordion-by-adam-silver.md
+++ b/posts/this-week-i-used-an-accordion-by-adam-silver.md
@@ -13,7 +13,6 @@ tags:
 linkTarget: https://ckarchive.com/b/n4uohvh8pzr7ou7q339qeh7o4eggghl
 ---
 I loved this insight into Adam Silver’s thought process. And it came at a timely moment since at work I’m currently trying to promote evidence-based, considered choices regarding user interface patterns.
----
 
 My summary of Adam’s key points is:
 

--- a/posts/thoughts-on-html-over-the-wire-solutions.md
+++ b/posts/thoughts-on-html-over-the-wire-solutions.md
@@ -24,7 +24,6 @@ draft: false
 
 > htmx (and similar "HTML over the wire" approaches) could someday replace Javascript SPAs. Cool to see a real-world case study on that, and with promising results
 
----
 
 There’s similar excitement at my place of work (and among the Rails community in general) about [Turbo](https://turbo.hotwired.dev/). It promises:
 

--- a/posts/thoughts-on-the-15-minute-city-the-book-and-the-concept.md
+++ b/posts/thoughts-on-the-15-minute-city-the-book-and-the-concept.md
@@ -16,16 +16,15 @@ mainImage.isAnchor: false
 draft: false
 
 ---
-I really enjoyed [The 15 Minute City](https://uk.bookshop.org/books/the-15-minute-city-global-change-through-local-living/9781910022474) by Natalie Whittle. 
+I really enjoyed [The 15 Minute City](https://uk.bookshop.org/books/the-15-minute-city-global-change-through-local-living/9781910022474) by Natalie Whittle.
 
 It presents the idea of modern cities in which residents can reach everything they need – shopping, work, school, green space, transport, exercise, culture etc – within 15 minutes on foot or by bike.
----
 
-This idea is already working (or making good progress) in cities like Amsterdam and Paris. 
+This idea is already working (or making good progress) in cities like Amsterdam and Paris.
 
 And during periods of restriction during the Covid-19 pandemic it’s a way of life that people around the world have been forced to try.
 
-There are numerous potential benefits of the idea – for example for physical and mental health, the environment, gaining more family and social time from less commuting, boosting neighbourhood economies through shopping local and so on. 
+There are numerous potential benefits of the idea – for example for physical and mental health, the environment, gaining more family and social time from less commuting, boosting neighbourhood economies through shopping local and so on.
 
 On the other hand the 15-minute idea arguably favours the middle-class over the working-class, leads to diminished interpersonal skills, and ignores the important role of cities (such as London) in performing a wider, globally-connected role.
 

--- a/posts/to-delete-something-use-a-form-rather-than-a-link.md
+++ b/posts/to-delete-something-use-a-form-rather-than-a-link.md
@@ -25,7 +25,6 @@ draft: false
 In web-based products from e-commerce stores to email clients to accounting software you often find index pages where each item in a list (or row in a table) has a _Delete_ option. This is often coded as a link… but it shouldn’t be.
 
 I liked this comment by Rails developer Dan where he advises a fellow Rails developer that to create his Delete control he should use a form rather than a link, via Rails’s `button_to` method.
----
 
 Dan mentions that in the past Rails UJS set an unsdesirable historical precedent by including a pattern of hijacking links for non-GET reqests.
 

--- a/posts/trying-out-css-cascade-layers.md
+++ b/posts/trying-out-css-cascade-layers.md
@@ -15,7 +15,6 @@ mainImage.isAnchor: false
 
 ---
 Back in June I attended CSS Day in Amsterdam. One of my favourite talks was [The CSS Cascade – A Deep Dive](https://www.youtube.com/watch?v=zEPXyqj7pEA) by Bramus van Damme. Bramus covered everything we wanted to know about the cascade but were afraid to ask! And that included an introduction to CSS _Cascade Layers_ – the latest game-changing CSS feature.
----
 
 I previously [enjoyed Stephanie Eckles’s article _Getting Started with CSS Cascade Layers_](https://fuzzylogic.me/posts/getting-started-with-css-cascade-layers-by-stephanie-eckles/) so my interest was already piqued. However seeing Bramus’s talk in person really helped bring home the practical benefits of CSS layers. 
 

--- a/posts/unsplash-beautiful-free-images-and-pictures.md
+++ b/posts/unsplash-beautiful-free-images-and-pictures.md
@@ -6,7 +6,6 @@ tags: [link, stock, photography]
 linkTarget: "https://source.unsplash.com/"
 ---
 > The internet’s source of freely usable images. Powered by creators everywhere.
----
 
 I’ve seen a couple of other developers use [photos from Unsplash](https://unsplash.com/) in their demos, and it just came in handy for me recently when needing some free food photography for a website.
 

--- a/posts/use-an-anchor-for-downloads.md
+++ b/posts/use-an-anchor-for-downloads.md
@@ -10,10 +10,9 @@ tags:
 - ux
 linkTarget: https://css-tricks.com/building-good-download-button/
 ---
-Question: when presenting users with a means of downloading a file, should you use the `anchor` element or the `button` element? 
+Question: when presenting users with a means of downloading a file, should you use the `anchor` element or the `button` element?
 
 Answer: you should use the `anchor` element.
----
 
 Eric starts by quoting accessibility expert Scott O’Hara to explain why anchor is the appropriate element:
 

--- a/posts/use-eleventy-templating-to-include-static-code-demos.md
+++ b/posts/use-eleventy-templating-to-include-static-code-demos.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 Here’s a great tutorial from Eleventy guru [Stephanie Eckles](https://twitter.com/5t3ph) in which she explains how to create a page that displays multiple code demos, similar to [SmolCSS.dev](https://smolcss.dev/).
----
 
 It’s interesting that Stephanie uses 11ty shortcodes over [other 11ty templating options]( https://fuzzylogic.me/posts/reusable-code-snippets-and-components-in-eleventy/) and that she sometimes declares a variable (via Nunjucks’s `set`) at the top of the page then intentionally _reuses it unchanged_ in repeated shortcode instances… the example being times where you want to illustrate the same HTML code (variable) being styled differently in progressive demos.
 

--- a/posts/use-the-dialog-element-reasonably-by-scott-o-hara.md
+++ b/posts/use-the-dialog-element-reasonably-by-scott-o-hara.md
@@ -14,7 +14,6 @@ draft: false
 
 ---
 Here’s an important update on _native modal dialogues_. TL;DR – it’s now OK to use `dialog`.
----
 
 Last year [I posted that Safari now supported the HTML `dialog` element](https://fuzzylogic.me/posts/refactoring-a-modal-dialogue-in-2022/) meaning that we were within touching distance of being able to adopt it with confidence. My caveat was:
 

--- a/posts/using-aria-current-is-a-win-win-situation.md
+++ b/posts/using-aria-current-is-a-win-win-situation.md
@@ -23,7 +23,6 @@ draft: false
 
 ---
 The HTML attribute `aria-current` allows us to indicate the currently active element in a sequence. It’s not only great for accessibility but also doubles as a hook to style that element individually.
----
 
 By using `[aria-current]` as your CSS selector (rather than a `.current` class) this also neatly binds and syncs the way you cater to the visual experience and the screen reader experience, reducing the ability for the latter to be forgotten about.
 

--- a/posts/using-css-custom-properties-to-streamline-animation.md
+++ b/posts/using-css-custom-properties-to-streamline-animation.md
@@ -9,7 +9,6 @@ tags:
   - transform
 ---
 Thanks to [a great tip from Lucas Hugdahl on Twitter](https://twitter.com/LucasHugdahl/status/1190438217482264576), here’s how to use CSS custom properties (variables) in your transforms so you don't need to rewrite the whole `transform` rule in order to `transition` (animate) a single property.
----
 
 Let’s take the simple example of a `button` that we want to increase in size when hovered.
 

--- a/posts/using-css-display-contents-to-snap-grandchild-elements-to-a-grid.md
+++ b/posts/using-css-display-contents-to-snap-grandchild-elements-to-a-grid.md
@@ -11,7 +11,6 @@ tags:
   - development
 ---
 I realised last night while watching a presentation by Lea Verou that I could streamline my CSS Grid layouts.
----
 
 I’d been creating an overall page grid by setting `body { display: grid; }` then some grid areas but realised that this only worked for direct children and didn’t help with aligning more deeply nested elements to that outer grid.
 

--- a/posts/using-css-grid-instead-of-absolute-positioning.md
+++ b/posts/using-css-grid-instead-of-absolute-positioning.md
@@ -19,7 +19,6 @@ draft: false
 
 ---
 A while back I bookmarked Michelle Barker’s [CSS Grid based overlay technique](https://fuzzylogic.me/posts/2021-01-06-a-utility-class-for-covering-elements-on-css-in-real-life/) which neatly allows layering one element atop another using CSS Grid rather than absolute positioning. Now, Stephanie Eckles has taken the idea a step further with her [Smol Stack Layout](https://smolcss.dev/#smol-stack-layout) which offers a more flexible markup structure, some intuitive grid area naming and a neat `aspect-ratio` API.
----
 
 Stephanie’s component is feature-packed and opinionated to the extent that it took me a while to understand all the moving parts. So for simplicity I’ve created a pared-back version on CodePen: see [Layering utility with CSS Grid](https://codepen.io/fuzzylogicx/pen/XWZNqqo).
 

--- a/posts/using-the-has-pseudo-class-for-real.md
+++ b/posts/using-the-has-pseudo-class-for-real.md
@@ -26,7 +26,6 @@ By day I’m currently working on our Design System’s _Table_ component. In or
 2. if there is no `<tfoot>` then set all cells in the final row of the `<tbody>` to have no bottom-border.
 
 Modern CSS’s support for writing selectors which traverse the DOM _up, down and sideways_ is pretty amazing here.
----
 
 I’ve gone with:
 

--- a/posts/using-the-tabindex-attribute.md
+++ b/posts/using-the-tabindex-attribute.md
@@ -6,7 +6,6 @@ linkTarget: https://developer.paciellogroup.com/blog/2014/08/using-the-tabindex-
 tags: [link, a11y, focus, tab, tabbingorder, keyboardnavigation, order, cssgrid, flexbox]
 ---
 Léonie Watson explains how the HTML tabindex attribute is used to manage keyboard focus. Of particular interest to me was a clarification of what `tabindex="-1"` does (because I always forget).
----
 
 ## tabindex="-1"
 

--- a/posts/visit-to-north-berwick.md
+++ b/posts/visit-to-north-berwick.md
@@ -19,7 +19,6 @@ draft: false
 
 ---
 During a recent November week off I enjoyed a first visit to North Berwick. It’s a beautiful seaside town and I was lucky enough to get lovely cold-but-sunny winter weather.
----
 
 Here are some of the things I did:
 

--- a/posts/w3c-design-system.md
+++ b/posts/w3c-design-system.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 The [W3C](https://www.w3.org/Consortium/) have just published a new Design System. It was developed by British Digital Agency [Studio 24](), who are also working (in the open) on [the redesign of the W3C website](https://www.studio24.net/work/working-in-the-open-with-w3c/).
----
 
 My initial impression is that this Design System feels pretty early-stage and work-in-progress. I’m not completely sold on _all_ of the technical details, however it definitely contains a number of emergent best practices and lots of interesting parts.
 

--- a/posts/we-don-t-need-a-hamburger-icon.md
+++ b/posts/we-don-t-need-a-hamburger-icon.md
@@ -5,7 +5,6 @@ description: ''
 tags: []
 linkTarget: https://mailchi.mp/smashingmagazine.com/we-dont-need-a-hamburger-icon
 draft: true
-
 ---
 
 Smashing Magazine have recently been making the point that “hamburger menus” are proven to be problematic and violate Luke Wroblewski’s _Obvious Always Wins_ mantra.
@@ -20,4 +19,4 @@ That’s interesting, but there’s no citation and I don’t like that. However
 
 [https://www.nngroup.com/articles/hamburger-menus/](https://www.nngroup.com/articles/hamburger-menus/ "https://www.nngroup.com/articles/hamburger-menus/")
 
-In a follow-up they suggest that we should [never hide critical navigation on mobile](https://mailchi.mp/smashingmagazine.com/never-hide-critical-navigation-on-mobile). This post usefully offers a few alternative navigation patterns. 
+In a follow-up they suggest that we should [never hide critical navigation on mobile](https://mailchi.mp/smashingmagazine.com/never-hide-critical-navigation-on-mobile). This post usefully offers a few alternative navigation patterns.

--- a/posts/we-use-too-many-damn-modals-modalzmodalzmodalz.com.md
+++ b/posts/we-use-too-many-damn-modals-modalzmodalzmodalz.com.md
@@ -11,7 +11,6 @@ draft: false
 
 ---
 At our fortnightly Accessibility Forum at work, we just had a great discussion about modal dialogues. We started by discussing whether focus should be completely trapped within the modal or if the user should at least have access to the browser toolbar (we decided on the former). We then moved onto a general discussion on the pros and cons of modals, which led me to share MODALZ MODALZ MODALZ with the team.
----
 
 Adrian Egger’s website presents some interesting suggestions, which I’ll summarise below:
 

--- a/posts/web-animation-tips.md
+++ b/posts/web-animation-tips.md
@@ -25,7 +25,6 @@ Warning: this entry is a work-in-progress and incomplete. That said, it's still 
 There are lots of different strands of web development. You try your best to be good at all of them, but there’s only so much time in the day! Animation is an area where I know _a little_ but would love to know more, and from a practical perspective I’d certainly benefit from having some road-ready solutions to common challenges. As ever I want to favour web standards over libraries where possible, and take an approach that’s lean, accessible, progressively-enhanced and performance-optimised.
 
 Here’s my attempt to break down web animation into bite-sized chunks for ocassional users like myself.
----
 
 ## Defining animation
 

--- a/posts/web-components-as-progressive-enhancement-by-cloud-four.md
+++ b/posts/web-components-as-progressive-enhancement-by-cloud-four.md
@@ -24,7 +24,6 @@ draft: false
 > _By enhancing native HTML instead of replacing it, we can provide a solid baseline experience, and add progressive enhancement as the cherry on top._
 
 Great article by Paul Herbert of Oregon’s Cloud Four. Using a web component to enhance an existing HTML element such as `<textarea>` (rather than always creating a custom element from scratch) feels very lean, resilient and maintainable.
----
 
 Off the top of my head I could see this being a nice approach for other custom form controls.
 

--- a/posts/web-components-guide.md
+++ b/posts/web-components-guide.md
@@ -12,7 +12,6 @@ draft: false
 
 ---
 This new resource on Web Components from Keith Cirkel and Kristján Oddsson of GitHub (and friends) is looking great so far.
----
 
 As [I recently tweeted](https://twitter.com/fuzzylogicx/status/1614202359520919553), I love that it’s demoing “vanilla” Web Components first rather than using a library for the demos. 
 

--- a/posts/web-components-with-declarative-shadow-dom-via-lit-and-eleventy.md
+++ b/posts/web-components-with-declarative-shadow-dom-via-lit-and-eleventy.md
@@ -25,7 +25,6 @@ draft: false
 
 ---
 Here’s a new development in the Web Components story, and one that may have positive implications for resilience, performance and progressive enhancement.
----
 
 [Declarative Shadow DOM](https://web.dev/declarative-shadow-dom/) is a new way to implement and use Shadow DOM directly in HTML rather than by constructing a shadow root in JavaScript.
 

--- a/posts/webc.md
+++ b/posts/webc.md
@@ -22,7 +22,6 @@ draft: false
 
 ---
 WebC, the latest addition to the [Eleventy](https://www.11ty.dev/) suite of technologies, is focused on making [Web Components](https://developer.mozilla.org/en-US/docs/Web/Web_Components) easier to use. I have to admit, it took me a while to work out the idea behind this one, but I see it now and it looks interesting.
----
 
 Here are a few of the selling points for WebC, as I see them.
 

--- a/posts/webfont-loading-strategies.md
+++ b/posts/webfont-loading-strategies.md
@@ -16,7 +16,6 @@ tags:
 draft: false
 ---
 When it comes to webfonts, if you want to serve an accessible and high performance experience across device types it’s not as straightforward as just specifying your fonts in CSS then hoping for the best.
----
 
 We likely have goals such as the following:
 

--- a/posts/webmention.app-automate-your-outgoing-webmentions.md
+++ b/posts/webmention.app-automate-your-outgoing-webmentions.md
@@ -17,6 +17,5 @@ draft: false
 
 ---
 [webmention.app](https://webmention.app) is a great new project by [Remy Sharp](https://remysharp.com/). He created it because he noticed that while adding webmentions to your site is relatively straightforward, sending outgoing webmentions is less so.
----
 
 At the moment my personal website is Perch-based and I have webmentions enabled, so let’s see what happens when I <a class="u-in-reply-to" href="https://remysharp.com/2019/06/18/send-outgoing-webmentions">link to Remy’s explainer article</a>.

--- a/posts/weekend-at-drinkbetween-cottage.md
+++ b/posts/weekend-at-drinkbetween-cottage.md
@@ -19,7 +19,6 @@ mainImage.isAnchor: false
 draft: false
 ---
 Me, Clair and Rudy just enjoyed a lovely weekend break. We stayed at [Drinkbetween cottage on Banchory Farm](https://www.banchoryfarm.co.uk/general-5). While only 70 minutes drive from home it provided some lovely countryside isolation, with the bonus of nice nearby towns to visit nearby too.
----
 
 The cottage has recently been restored by the farm owners and was the perfect environment to relax. 
 

--- a/posts/weekend-notes-18-10-24.md
+++ b/posts/weekend-notes-18-10-24.md
@@ -18,7 +18,6 @@ That was a productive and fun weekend.
 
 On Friday, Clair was meeting her mum and cousin in town so this was my quiet night in. I settled down to watch episode 4 of the _The Penguin_ and ordered fish tikka from [Kebabish](https://www.kebabishgrill.co.uk/) – banging).
 
----
 
 I started Saturday with a short Rudy-walk then it was off to Pete’s for some table-tennis practice. I’ve been playing crap recently and wanted to fix things. Pete was as generous as ever with his tips, and his advice on “the triangle” and "dialling up/down power" was really effective! By the end I was playing both forehand and backhand much better.  After this I drove out to Kirky and collected my brother Martin to go for a chat over lunch at Nonna’s Kitchen. On the way home we popped into my niece Chloe’s new house and I enjoyed chasing wee Leo around his garden. At night Clair and I stayed in and watched _Where the Crawdads Sing_ which was enjoyable enough.
 

--- a/posts/well-known-avatar.md
+++ b/posts/well-known-avatar.md
@@ -20,7 +20,6 @@ draft: false
 
 ---
 I really like Jim’s idea of putting an avatar file somewhere that’s memorable and easy to access by me wherever I am and that also (in the future) might be automatically grabbable by any platform that needs my avatar.
----
 
 So I’ve put my avatar at [fuzzylogic.me/.well-known/avatar](https://fuzzylogic.me/.well-known/avatar).
 

--- a/posts/what-open-source-design-systems-are-built-with-web-components.md
+++ b/posts/what-open-source-design-systems-are-built-with-web-components.md
@@ -29,7 +29,6 @@ Alex Page, a Design System engineer at Spotify, has just asked:
 > What open-source design systems are built with web components? Anyone exploring this space? Curious to learn what is working and what is challenging. [#designsystems](https://twitter.com/hashtag/designsystems?src=hashtag_click) [#webcomponents](https://twitter.com/hashtag/webcomponents?src=hashtag_click)
 
 And there are lots of interesting examples in the replies.
----
 
 I plan to read up on some of the stories behind these systems.
 

--- a/posts/why-much-of-the-internet-is-closed-off-to-blind-people.md
+++ b/posts/why-much-of-the-internet-is-closed-off-to-blind-people.md
@@ -6,6 +6,5 @@ tags: [link, a11y, alistapart]
 linkTarget: https://www.bbc.co.uk/news/world-us-canada-49694453
 ---
 Following the recent watershed [Domino’s Pizza case](https://fuzzylogic.me/posts/dominos-lose-appeal-regarding-digital-accessibility/), BBC News reports that retailers in the USA & Canada are struggling to make their websites accessible and consumers are taking them to court.
----
 
 > "We've even been told by businesses before that they understand, but the fact is blind people are not a very big market," Mr Danielson says. "That's what we are dealing with."

--- a/posts/words-and-phrases-i-always-struggle-with.md
+++ b/posts/words-and-phrases-i-always-struggle-with.md
@@ -24,7 +24,6 @@ draft: false
 
 ---
 I’m not sure if it‘s just me, but there are certain words and phrases which—no matter how many times I look up—just seem to be beyond me! So I’ve decided to note their meanings for future reference. Hopefully this might help make the meanings stick.
----
 
 <dl>
   <dt>Hubris</dt>


### PR DESCRIPTION
Removing this makes the code much simpler and therefore updates easier. 

In near future I can 
- add a class of intro to the first paragraph of posts when I want it (and style that to look distinct), 
- add a boolean front-matter key like `inListsShowDescription` (or maybe better just check for a first tag of "entry/article") then in lists show the `description` value plus a “Continue reading” link, rather than showing the full content of the article.