### PR TITLE
Only share shareworthy posts in RSS feed

### DIFF
--- a/content/posts/2025-03-30-11-18.md
+++ b/content/posts/2025-03-30-11-18.md
@@ -2,7 +2,6 @@
 title: Confessions of a Shinigawa Monkey
 description: Loved this Haruki Murakami production at Glasgow’s Tramway theatre
 noteWithTitle: true
-pageSpecificRobotsDirective: ""
 date: 2025-02-22T23:18
 tags:
   - note
@@ -13,7 +12,7 @@ tags:
   - arts
 location: Tramway theatre, Glasgow
 ---
-Had a great local night out there. After meeting Gillian and Aarti for some lovely food at [Lobo](https://www.loboglasgow.co.uk/), Clair joined us at the local [Tramway theatre](https://www.tramway.org/) for the show. 
+Had a great local night out there. After meeting Gillian and Aarti for some lovely food at [Lobo](https://www.loboglasgow.co.uk/), Clair joined us at the local [Tramway theatre](https://www.tramway.org/) for the show.
 
 I’ve previously read and enjoyed a couple of Haruki Marukami’s books and from [what I’ve learned about his interests](https://uk.bookshop.org/p/books/what-i-talk-about-when-i-talk-about-running-haruki-murakami/1275627) I generally like the cut of his jib. So it was great to hear that there’d be a Murakami theatre production on our doorstep, and intriguing to see how they’d pull off the weird, dreamy nature of his stories. As it happens our neighbour Matt is the artistic director of [Vanishing Point](https://vanishing-point.org/) and he’d already mentioned in passing that they’d been collaborating with Japanese organisation [KAAT](https://www.kaat.jp/), so I’d been looking out for this one.
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -78,7 +78,19 @@ export default async function(eleventyConfig) {
 		bundleHtmlContentFromSelector: "script",
 	});
 
-	// Official plugins
+  // Create a custom collection of feed-friendly posts.
+  // They exclude posts that have the key 'pageSpecificRobotsDirective'
+  // (which, when I apply it, I set to "noindex, nofollow").
+  // These are pretty personal (and sometimes trivial) notes that I don’t
+  // need indexed on google, and I can use that same flag to not share with my RSS subscribers.
+  // Ref: https://www.11ty.dev/docs/collections-api/
+  eleventyConfig.addCollection("feedPosts", async (collectionsApi) => {
+ 		return collectionsApi.getFilteredByTag("posts").filter(function (item) {
+			return ("pageSpecificRobotsDirective" in item.data === false);
+		});
+	});
+
+  // Official plugins
 	eleventyConfig.addPlugin(pluginSyntaxHighlight, {
 		preAttributes: { tabindex: 0 }
 	});
@@ -97,7 +109,7 @@ export default async function(eleventyConfig) {
 			}
 		},
 		collection: {
-			name: "posts",
+			name: "feedPosts",
 			limit: 10,
 		},
 		metadata: {


### PR DESCRIPTION
Creates a custom collection of feed-friendly posts (`feedPosts`) so that my feed subscribers don’t get trivial posts about me meeting old pals