### PR TITLE
Fixes DecapCMS public image path

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -3,6 +3,7 @@ backend:
   branch: v3
 publish_mode: editorial_workflow
 media_folder: "content/img/uploads"
+public_folder: "/img"
 collections:
   - name: "blog" # Used in routes, e.g., /admin/collections/blog
     label: "Blog" # Used in the UI


### PR DESCRIPTION
In Decap CMS’s post editor I was able to grab images from the media library fine because the config’s `media_folder` value was correct. 
But the image in the saved post had the wrong file path. Which meant that 11ty image had problemns. This fixes that.