### PR TITLE
Some image improvements

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -1,17 +1,29 @@
 import { DateTime } from "luxon";
 
 export default function(eleventyConfig) {
-	eleventyConfig.addFilter("readableDate", (dateObj, format, zone) => {
-		// Formatting tokens for Luxon: https://moment.github.io/luxon/#/formatting?id=table-of-tokens
-		return DateTime.fromJSDate(dateObj, { zone: zone || "utc" }).toFormat(format || "dd LLLL yyyy");
-	});
-
 	// LH DIY’d.
   // TODO: decide if time-precision is necessary; ditch if not.
   eleventyConfig.addFilter("readableTime", (dateObj, format, zone) => {
 		// Formatting tokens for Luxon: https://moment.github.io/luxon/#/formatting?id=table-of-tokens
     return DateTime.fromJSDate(dateObj, { zone: zone || "utc" }).toFormat(format || "h:mm a");
 	});
+
+  // apply HTML `loading` and `decoding` attributes to images
+  // so that they override my 11ty Image plugin “sensible defaults”
+  // on above the fold images which *should* be loaded eagerly.
+  eleventyConfig.addFilter("loadFirstImageInPostSynchronously", (postContent) => {
+    // apply replacement to first img instance only
+    // Handily, that’s how replace() works by default
+    return postContent.replace('<img ', '<img loading="eager" decoding="auto" ');
+	});
+  // end LH DIY’d
+
+  eleventyConfig.addFilter("readableDate", (dateObj, format, zone) => {
+		// Formatting tokens for Luxon: https://moment.github.io/luxon/#/formatting?id=table-of-tokens
+		return DateTime.fromJSDate(dateObj, { zone: zone || "utc" }).toFormat(format || "dd LLLL yyyy");
+	});
+
+
 
 	eleventyConfig.addFilter("htmlDateString", (dateObj) => {
 		// dateObj input: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-date-string

--- a/_config/filters.js
+++ b/_config/filters.js
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import markdownIt from "markdown-it";
 
 export default function(eleventyConfig) {
 	// LH DIY’d.
@@ -7,6 +8,15 @@ export default function(eleventyConfig) {
 		// Formatting tokens for Luxon: https://moment.github.io/luxon/#/formatting?id=table-of-tokens
     return DateTime.fromJSDate(dateObj, { zone: zone || "utc" }).toFormat(format || "h:mm a");
 	});
+
+  // Convert raw markdown to HTML
+  // Useful when using the `page.data.excerpt` that 11ty makes available
+  // because it comes as raw markdown, but I want bolding and italics etc to render properly…
+  // so I pass the excerpts through this.
+  // Ref: https://github.com/11ty/eleventy/issues/1380#issuecomment-698457560
+  eleventyConfig.addFilter("md", (content = "") => {
+    return markdownIt().render(content);
+  });
 
   // apply HTML `loading` and `decoding` attributes to images
   // so that they override my 11ty Image plugin “sensible defaults”

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -50,7 +50,7 @@ templateClass: post-main
 
       <div class="l-flow e-content {{ "article-type-listing" if isList }}" itemprop="articleBody">
 
-        {{ content | safe }}
+        {{ content | loadFirstImageInPostSynchronously | safe }}
 
       </div> <!-- /.e-content -->
 

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -19,7 +19,11 @@
       </div>
     </header>
     <div class="l-flow e-content">
-      {{ post.content | safe }}
+      {% if (loop.first) -%}
+        {{ post.content | loadFirstImageInPostSynchronously | safe }}
+      {% else -%}
+        {{ post.content | safe }}
+      {% endif -%}
     </div>
     {# <footer>
       <a rel="bookmark" class="p-name u-url" href="{{ post.url | url }}">

--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -19,17 +19,24 @@
       </div>
     </header>
     <div class="l-flow e-content">
+      {% set post_content = post.content %}
+      {% if (post.page.excerpt) -%}
+        {% set post_content = post.page.excerpt | md %}
+      {% endif -%}
+
       {% if (loop.first) -%}
-        {{ post.content | loadFirstImageInPostSynchronously | safe }}
+        {{ post_content | loadFirstImageInPostSynchronously | safe }}
       {% else -%}
-        {{ post.content | safe }}
+        {{ post_content | safe }}
       {% endif -%}
     </div>
-    {# <footer>
+    {% if (post.page.excerpt) -%}
+    <footer>
       <a rel="bookmark" class="p-name u-url" href="{{ post.url | url }}">
         Continue reading <span class="u-visually-hidden">“{{ post.data.title }}”</span>
       </a>
-    </footer> #}
+    </footer>
+    {% endif -%}
 
     {# <footer class="stack">
       <div class="cluster">

--- a/content/posts/test-11ty-image.md
+++ b/content/posts/test-11ty-image.md
@@ -11,10 +11,7 @@ draft: false
 ---
 I’m testing out the [Eleventy Image plugin](https://www.11ty.dev/docs/plugins/image/). Here’s a post with an image which, if all goes well, will be converted by the plugin from source `jpeg` into lightweight `avif` and `webp` formats and the underlying code transformed from a basic `img` element into comprehensive modern HTML image syntax.
 
-<!-- This image is near the top of the page and could be regarded as important in the LCP.
-So let’s unset the customisations to the loading and decoding attributes
-and make the image loading synchronous. -->
 <figure>
-  <img decoding="auto" loading="eager" alt="A photo of the sign at the entrance to La Petite Garoupe restaurant, Antibes. The letters are in neon and the sign is surrounded by flowers." src="/img/uploads/img_4088.jpeg" />
+  <img alt="A photo of the sign at the entrance to La Petite Garoupe restaurant, Antibes. The letters are in neon and the sign is surrounded by flowers." src="/img/uploads/img_4088.jpeg" />
   <figcaption>Entrance sign at La Petite Garoupe restaurant, Antibes</figcaption>
 </figure>

--- a/content/posts/website-updates.md
+++ b/content/posts/website-updates.md
@@ -11,9 +11,11 @@ tags:
   - personalsite
   - personalsites
 ---
-I’ve recently been updating my website over a series of nights and weekends. The changes aren’t very noticeable to the eye; they mostly involved modernising and streamlining back-end features and technology, plus some improvements to accessibility and performance. I’m really happy to have made them!
+I’ve recently been updating my website over a series of nights and weekends. The changes aren’t very noticeable to the eye but involved some careful modernisation and streamlining of back-end features and technology, plus improvements to accessibility and performance. I’m really happy to have made them.{.post__intro}
 
-About a year ago I wrote about [the features I wanted on my personal website versus those it had](https://fuzzylogic.me/posts/features-of-my-personal-site/). The work I’ve been doing recently has helped to plug the gaps. 
+<!-- excerpt -->
+
+About a year ago I wrote about [the features I wanted on my personal website versus those it had](https://fuzzylogic.me/posts/features-of-my-personal-site/). The work I’ve been doing recently has helped to plug the gaps.
 
 During this work I documented the latest features of my website [on the readme of my public website repository](https://github.com/fuzzylogicxx/fuzzylogic). I find it really useful to be able to see this information at a glance. It’ll also make life much easier when I want to tweak things in the future.
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -16,9 +16,15 @@ import pluginFilters from "./_config/filters.js";
 // the markdown content.
 import markdownItAttrs from 'markdown-it-attrs';
 
+// use markdown-it-anchors to turn the paragraphs that markdown-it automatically
+// wraps around images into <figure>s.
+import markdownItImplicitFigures from 'markdown-it-implicit-figures';
+
 // use cssnano (which is a configuration for postcss) to transform/minify the CSS we’ll bundle with 11ty Bundle
 import postCSS from "postcss";
 import cssNano from "cssnano";
+
+// end LH custom imports
 
 /** @param {import("@11ty/eleventy").UserConfig} eleventyConfig */
 export default async function(eleventyConfig) {
@@ -32,6 +38,7 @@ export default async function(eleventyConfig) {
   // Add my own choice of plugins for markdown-it (I want markkdownItAttrs) to 11ty’s provided markdown-it instance.
   // Ref: https://www.11ty.dev/docs/languages/markdown/#add-your-own-plugins
   eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItAttrs));
+  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItImplicitFigures));
 
 	// Copy the contents of the `public` folder to the output folder
 	// For example, `./public/css/` ends up in `_site/css/`

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -97,6 +97,12 @@ export default async function(eleventyConfig) {
 		});
 	});
 
+	eleventyConfig.setFrontMatterParsingOptions({
+		excerpt: true,
+		// Optional, default is "---"
+		excerpt_separator: "<!-- excerpt -->",
+	});
+
   // Official plugins
 	eleventyConfig.addPlugin(pluginSyntaxHighlight, {
 		preAttributes: { tabindex: 0 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "dotenv": "^8.2.0",
         "luxon": "^3.5.0",
         "markdown-it-attrs": "^4.3.1",
+        "markdown-it-implicit-figures": "^0.12.0",
         "postcss": "^8.5.6",
         "zod": "^3.24.1",
         "zod-validation-error": "^3.4.0"
@@ -1948,6 +1949,15 @@
       },
       "peerDependencies": {
         "markdown-it": ">= 9.0.0"
+      }
+    },
+    "node_modules/markdown-it-implicit-figures": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-implicit-figures/-/markdown-it-implicit-figures-0.12.0.tgz",
+      "integrity": "sha512-IeD2V74f3ZBYrZ+bz/9uEGii0S61BYoD2731qsHTgYLlENUrTevlgODScScS1CK44/TV9ddlufGHCYCQueh1rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/markdown-it/node_modules/argparse": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dotenv": "^8.2.0",
     "luxon": "^3.5.0",
     "markdown-it-attrs": "^4.3.1",
+    "markdown-it-implicit-figures": "^0.12.0",
     "postcss": "^8.5.6",
     "zod": "^3.24.1",
     "zod-validation-error": "^3.4.0"


### PR DESCRIPTION
**Images**
- I now have the post and postlist template running content (when appropriate) through a new filter called `loadFirstImageInPostSynchronously`. It sets loading=eager and decoding=auto to override the otherwise-sensible defaults that Eleventy Image plugin would add in the cases where we want above the fold images loaded synchronously.
- by adding the `markdown-it-implicit-figures` plugin, I’m making `markdown-it` use `figure` rather than `p` as the wrapping element for images.

**Excerpts:** 
- restarts using greymatter excerpts with better delimiter (less conflicty with horizontal breaks and headings
- introduces a new filter (`md`) to parse markdown into HTML on-demand (as is needed to work with 11ty’s post.page.excerpt cos it will deliver markdown raw)
