### PR TITLE
Support use of attrs in markdown excerpts

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -1,5 +1,6 @@
 import { DateTime } from "luxon";
 import markdownIt from "markdown-it";
+import markdownItAttrs from 'markdown-it-attrs';
 
 export default function(eleventyConfig) {
 	// LH DIY’d.
@@ -15,7 +16,7 @@ export default function(eleventyConfig) {
   // so I pass the excerpts through this.
   // Ref: https://github.com/11ty/eleventy/issues/1380#issuecomment-698457560
   eleventyConfig.addFilter("md", (content = "") => {
-    return markdownIt().render(content);
+    return markdownIt().use(markdownItAttrs).render(content);
   });
 
   // apply HTML `loading` and `decoding` attributes to images

--- a/content/posts/website-updates.md
+++ b/content/posts/website-updates.md
@@ -11,7 +11,7 @@ tags:
   - personalsite
   - personalsites
 ---
-I’ve recently been updating my website over a series of nights and weekends. The changes aren’t very noticeable to the eye but involved some careful modernisation and streamlining of back-end features and technology, plus improvements to accessibility and performance. I’m really happy to have made them.
+I’ve recently been updating my website over a series of nights and weekends. The changes aren’t very noticeable to the eye but involved some careful modernisation and streamlining of back-end features and technology, plus improvements to accessibility and performance. I’m really happy to have made them.{.post__intro}
 
 <!-- excerpt -->
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -37,8 +37,8 @@ export default async function(eleventyConfig) {
 
   // Add my own choice of plugins for markdown-it (I want markkdownItAttrs) to 11ty’s provided markdown-it instance.
   // Ref: https://www.11ty.dev/docs/languages/markdown/#add-your-own-plugins
-  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItAttrs));
   eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItImplicitFigures));
+  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItAttrs));
 
 	// Copy the contents of the `public` folder to the output folder
 	// For example, `./public/css/` ends up in `_site/css/`


### PR DESCRIPTION
In order to add `{.post__intro}` at the end of the first paragraphs of posts and have that correctly parsed into HTML not only in full posts but also _excerpts_, I needed to: 
update the `md` filter into which I pipe raw `post.page.excerpt` markdown/text so that it also `use`s `markdown-it-attrs`.