### PR TITLE
Apply fetchpriority=high to LCP images

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -21,10 +21,33 @@ export default function(eleventyConfig) {
   // apply HTML `loading` and `decoding` attributes to images
   // so that they override my 11ty Image plugin “sensible defaults”
   // on above the fold images which *should* be loaded eagerly.
-  eleventyConfig.addFilter("loadFirstImageInPostSynchronously", (postContent) => {
-    // apply replacement to first img instance only
-    // Handily, that’s how replace() works by default
-    return postContent.replace('<img ', '<img loading="eager" decoding="auto" ');
+  eleventyConfig.addFilter("loadFirstImageInPostSynchronously", (postContent, isLCPImage = false) => {
+    let isMatch = false;
+
+    if (typeof postContent === 'string') {
+      const relevantPart = postContent.slice(0, 450);
+      if (relevantPart.includes('<img ') && relevantPart.includes('<img eleventy:ignore') === false) {
+        isMatch = true;
+      }
+    }
+
+    if (isMatch) {
+      let replacement = '<img loading="eager" decoding="auto"';
+      if (isLCPImage) {
+        // on some pages (like the individual post page/template) there’s no banner,
+        // so the post’s first image can be considered “the LCP image”.
+        // so go further and set fetchpriority=high
+        // https://addyosmani.com/blog/fetch-priority/
+        replacement = '<img fetchpriority="high" loading="eager" decoding="auto"';
+      }
+
+      // apply replacement to first img instance only
+      // Handily, that’s how replace() works by default
+      // return postContent.replace('<img ', '<img loading="eager" decoding="auto" ');
+      return postContent.replace('<img ', replacement);
+    }
+
+    return postContent;
 	});
   // end LH DIY’d
 

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -50,7 +50,8 @@ templateClass: post-main
 
       <div class="l-flow e-content {{ "article-type-listing" if isList }}" itemprop="articleBody">
 
-        {{ content | loadFirstImageInPostSynchronously | safe }}
+        {%- set isLCPImage = true -%}
+        {{ content | loadFirstImageInPostSynchronously(isLCPImage) | safe }}
 
       </div> <!-- /.e-content -->
 


### PR DESCRIPTION
Updates my filter for synchronously loading a post’s first image so that it:

- skips `eleventy:ignored` images
- skips first images which appear later in the post, and
- also sets `fetchpriority=high` when we know it’s an LCP image