### PR TITLE
Add figcaption support in my markdown-it-implicit-figures config

### DIFF
--- a/_config/filters.js
+++ b/_config/filters.js
@@ -1,6 +1,7 @@
 import { DateTime } from "luxon";
 import markdownIt from "markdown-it";
 import markdownItAttrs from 'markdown-it-attrs';
+import markdownItImplicitFigures from 'markdown-it-implicit-figures';
 
 export default function(eleventyConfig) {
 	// LH DIY’d.
@@ -10,13 +11,21 @@ export default function(eleventyConfig) {
     return DateTime.fromJSDate(dateObj, { zone: zone || "utc" }).toFormat(format || "h:mm a");
 	});
 
-  // Convert raw markdown to HTML
-  // Useful when using the `page.data.excerpt` that 11ty makes available
-  // because it comes as raw markdown, but I want bolding and italics etc to render properly…
-  // so I pass the excerpts through this.
+  // Convert raw markdown to HTML.
+  // Useful when working with the `page.data.excerpt` that 11ty makes available,
+  // because it comes as raw markdown however when I use it as the content snippet
+  // per blog post in a list of posts, I want those excerpts rendered
+  // as proper HTML – with bolding, italics, links etc – a string doesn’t cut it.
+  // So I pass the excerpts through this.
+  // Note: the advanced markdown things I’m doing here (including <figure> around images etc)
+  // mirror the way I’ve configured 11ty’s own markdown parser in eleventy.config.js.
+  // I want the exact same HTML results when I generate HTML from markdown using this filter.
   // Ref: https://github.com/11ty/eleventy/issues/1380#issuecomment-698457560
   eleventyConfig.addFilter("md", (content = "") => {
-    return markdownIt().use(markdownItAttrs).render(content);
+    return markdownIt()
+      .use(markdownItAttrs)
+      .use(markdownItImplicitFigures, { figcaption: "title"})
+      .render(content);
   });
 
   // apply HTML `loading` and `decoding` attributes to images

--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -43,7 +43,7 @@ templateClass: post-main
       </div>
       {% endif %}
 
-      <div class="l-flow e-content {{ "article-type-listing" if isList }}" itemprop="articleBody">
+      <div class="l-flow e-content" itemprop="articleBody">
 
         {%- set isLCPImage = true -%}
         {{ content | loadFirstImageInPostSynchronously(isLCPImage) | safe }}

--- a/content/posts/something-somewhere-mix-nov-2025.md
+++ b/content/posts/something-somewhere-mix-nov-2025.md
@@ -18,17 +18,17 @@ tags:
   - mix
   - music
 ---
-Over the last few years I’ve played some radio shows but hadn’t done a mix of my own. I managed to rectify that the other night!
-
 ![A group of people gathered in a darkened room illuminated by deep reds and ambers](/img/uploads/somethingsomewhere.jpg "Photo by Clair Irwin")
+
+Over the last few years I’ve played some radio shows but hadn’t done a mix of my own. I managed to rectify that the other night.
 
 <!-- excerpt -->
 
-It’s a selection of lots of my favourite house-ish records of recent years, plus a few oldies. It includes plenty of my evergreen favourite artists and labels including Abacus, Legowelt and Dance Mania. I reckon my friend Davie would enjoy these tunes, so I’ll dedicate this one to him.
+This mix is a selection of my favourite house-ish records of recent years, plus a few oldies. It includes plenty of my evergreen favourite artists and labels including Abacus, Legowelt and Dance Mania. I reckon my friend Davie would enjoy these tunes, so I’ll dedicate this one to him.
 
 [Listen to the show on mixcloud.](https://www.mixcloud.com/laurencehughes/something-somewhere-dj-mix/)
 
-Here’s the tracklist:
+The tracklist is:
 
 1. Other Lands - The Caged Mind
 1. Reflection - Cube Loop (Morgan Geist mix)

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -17,7 +17,7 @@ import pluginFilters from "./_config/filters.js";
 import markdownItAttrs from 'markdown-it-attrs';
 
 // use markdown-it-anchors to turn the paragraphs that markdown-it automatically
-// wraps around images into <figure>s.
+// wraps around images into <figure>s instead.
 import markdownItImplicitFigures from 'markdown-it-implicit-figures';
 
 // use cssSnano (which is a configuration for postcss) to transform/minify the CSS we’ll bundle with 11ty Bundle
@@ -40,7 +40,11 @@ export default async function(eleventyConfig) {
 
   // Add my own choice of plugins for markdown-it (I want markkdownItAttrs) to 11ty’s provided markdown-it instance.
   // Ref: https://www.11ty.dev/docs/languages/markdown/#add-your-own-plugins
-  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItImplicitFigures));
+  eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(
+    markdownItImplicitFigures, {
+      figcaption: "title"
+    }
+  ));
   eleventyConfig.amendLibrary("md", (mdLib) => mdLib.use(markdownItAttrs));
 
 	// Copy the contents of the `public` folder to the output folder


### PR DESCRIPTION
## What

Adds figcaption support in my markdown-it-implicit-figures config

Now, what’s set as the markdown image `title` attribute is instead plucked out and used as the content of a `figcaption`.

I’ve applied this not only to 11ty’s own markdown parser but also my custom `md` 11ty _filter_ so that figcaptions are intelligently generated on excerpts too, rather than only in the main post template.

Lastly, I’ve updated the [_Something, Somewhere mix_ blog post](https://fuzzylogic.me/posts/something-somewhere-mix-nov-2025/) to take advantage and put the image (with figcaption) before the intro text in the excerpt, since that works better. 