### PR TITLE
Add “Mixes” to nav menu

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -163,7 +163,16 @@
             <ul role="list" class="l-cluster">
             {%- for entry in navPages %}
               <li class="primary-navigation__item" id="nav-{{ entry.title | lower }}">
-                <a{% if entry.url == page.url %} aria-current="page"{% endif %} href="{{ entry.url | url }}">{{ entry.title }}</a>
+                <a{% if entry.url == page.url %} aria-current="page"{% endif %} href="{{ entry.url | url }}">
+                  {% if entry.title === "Search" %}
+                    <svg aria-hidden="true" focusable="false" width="0.9em" height="0.9em">
+                        <use xlink:href="#icon-search"></use>
+                        <span class="u-visually-hidden">Search</span>
+                    </svg>
+                  {%- else -%}
+                    {{ entry.title }}
+                  {%- endif -%}
+                </a>
               </li>
             {%- endfor %}
             </ul>
@@ -193,24 +202,19 @@
     <!-- SVGs used repeatedly on the page are better defined as symbols, then <use>d -->
     <svg width="0" height="0" style="display: none;">
       <symbol id="icon-offsite" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <title>External Link</title>
         <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6M15 3h6v6M10 14L21 3"></path>
       </symbol>
       <symbol id="icon-bookmark" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <title>Bookmark</title>
         <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
       </symbol>
       <symbol id="icon-note" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <title>Note</title>
         <rect x="5" y="2" width="14" height="20" rx="2" ry="2"></rect><line x1="12" y1="18" x2="12" y2="18"></line>
       </symbol>
       <symbol id="icon-entry" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <title>Entry</title>
         <path d="M20.24 12.24a6 6 0 0 0-8.49-8.49L5 10.5V19h8.5z"></path><line x1="16" y1="8" x2="2" y2="22"></line><line x1="17.5" y1="15" x2="9" y2="15"></line>
       </symbol>
       <symbol id="icon-search" viewBox="0 0 56.966 56.966">
-        <title>Search</title>
-          <path fill="currentColor" d="M55.146 51.887L41.588 37.786A22.926 22.926 0 0 0 46.984 23c0-12.682-10.318-23-23-23s-23 10.318-23 23 10.318 23 23 23c4.761 0 9.298-1.436 13.177-4.162l13.661 14.208c.571.593 1.339.92 2.162.92.779 0 1.518-.297 2.079-.837a3.004 3.004 0 0 0 .083-4.242zM23.984 6c9.374 0 17 7.626 17 17s-7.626 17-17 17-17-7.626-17-17 7.626-17 17-17z"></path>
+        <path fill="currentColor" d="M55.146 51.887L41.588 37.786A22.926 22.926 0 0 0 46.984 23c0-12.682-10.318-23-23-23s-23 10.318-23 23 10.318 23 23 23c4.761 0 9.298-1.436 13.177-4.162l13.661 14.208c.571.593 1.339.92 2.162.92.779 0 1.518-.297 2.079-.837a3.004 3.004 0 0 0 .083-4.242zM23.984 6c9.374 0 17 7.626 17 17s-7.626 17-17 17-17-7.626-17-17 7.626-17 17-17z"></path>
       </symbol>
     </svg>
 

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -3,7 +3,7 @@ layout: layouts/page.njk
 title: About
 eleventyNavigation:
   key: About
-  order: 3
+  order: 4
 ---
 ## Web
 

--- a/content/contact/index.md
+++ b/content/contact/index.md
@@ -3,7 +3,7 @@ layout: layouts/page.njk
 title: Contact
 eleventyNavigation:
   key: Contact
-  order: 4
+  order: 5
 ---
 
 Want to get in touch? Please do, I’d love to hear from you! (Especially if you’re friendly and not trying to sell me something).

--- a/content/mixes.njk
+++ b/content/mixes.njk
@@ -1,6 +1,9 @@
 ---
 layout: layouts/page.njk
 title: Mixes
+eleventyNavigation:
+  key: Mixes
+  order: 2
 permalink: mixes/{% if pagination.pageNumber > 0 %}{{ pagination.pageNumber }}/{% endif %}index.html
 pagination:
   data: collections.my-mixes

--- a/content/search/index.md
+++ b/content/search/index.md
@@ -4,7 +4,7 @@ title: Search
 description: Seek and ye might find.
 eleventyNavigation:
   key: Search
-  order: 5
+  order: 6
 ---
 
 {#- Add the page-find web component JS to the JavaScript bundle #}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -135,7 +135,7 @@ export default async function(eleventyConfig) {
 		templateData: {
 			eleventyNavigation: {
 				key: "RSS",
-				order: 2
+				order: 3
 			}
 		},
 		collection: {


### PR DESCRIPTION
Previously there were five nav items and not much room on small screens for more.

I’ve added _Mixes_, changed the _Search_ link to use an icon rather than text (with visually hidden text for accessibility) and reordered the items so that _Mixes_ is second.