### PR TITLE
Show hash/direct links beside blog post section headings

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -9,68 +9,70 @@ templateClass: post-main
   }
 {% endcss %}
 
-<div class="primary-content__body">
-  <div class="l-center l-center--wrapper-narrow">
+<heading-anchors>
+  <div class="primary-content__body">
+    <div class="l-center l-center--wrapper-narrow">
 
-    <article
-      class="l-flow post h-entry prose"
-      itemscope itemtype="http://schema.org/BlogPosting"
-      data-pagefind-body
-    >
+      <article
+        class="l-flow post h-entry prose"
+        itemscope itemtype="http://schema.org/BlogPosting"
+        data-pagefind-body
+      >
 
-      <header class="post__header">
-        {%- if (title) -%}
-          {% set article_title = title %}
-        {%- else -%}
-          {% set article_title = "Note: " + (page.date | readableDate) + "," + (page.date | readableTime) %}
-        {%- endif -%}
-        {%- if (article_title) -%}<h1 class="post__heading p-name" itemprop="headline">{{ article_title }}</h1>{%- endif -%}
+        <header class="post__header">
+          {%- if (title) -%}
+            {% set article_title = title %}
+          {%- else -%}
+            {% set article_title = "Note: " + (page.date | readableDate) + "," + (page.date | readableTime) %}
+          {%- endif -%}
+          {%- if (article_title) -%}<h1 class="post__heading p-name" itemprop="headline">{{ article_title }}</h1>{%- endif -%}
 
-        <div class="post__meta">
-          <span class="u-visually-hidden">A {{ postType }} posted on</span>
-          <time itemprop="datePublished" class="dt-published" datetime="{{ page.date | htmlDateString }}">{{ page.date | readableDate }}</time>
-          in
-          <a rel="tag" href="/tags/{{ topLevelCategory | url }}" class="tag">{{ topLevelCategory }}</a>
+          <div class="post__meta">
+            <span class="u-visually-hidden">A {{ postType }} posted on</span>
+            <time itemprop="datePublished" class="dt-published" datetime="{{ page.date | htmlDateString }}">{{ page.date | readableDate }}</time>
+            in
+            <a rel="tag" href="/tags/{{ topLevelCategory | url }}" class="tag">{{ topLevelCategory }}</a>
+          </div>
+        </header>
+
+        {% if linkTarget %}
+        <div class="post-source">
+          <a class="text-icon-pair" href="{{ linkTarget }}">
+            <span>Visit external resource</span>
+            <svg class="text-icon-pair-icon" aria-hidden="true" focusable="false" width="1em" height="1em"><use xlink:href="#icon-offsite"></use></svg>
+          </a>
         </div>
-      </header>
+        {% endif %}
 
-      {% if linkTarget %}
-      <div class="post-source">
-        <a class="text-icon-pair" href="{{ linkTarget }}">
-          <span>Visit external resource</span>
-          <svg class="text-icon-pair-icon" aria-hidden="true" focusable="false" width="1em" height="1em"><use xlink:href="#icon-offsite"></use></svg>
-        </a>
-      </div>
-      {% endif %}
+        <div class="l-flow e-content" itemprop="articleBody">
 
-      <div class="l-flow e-content" itemprop="articleBody">
+          {%- set isLCPImage = true -%}
+          {{ content | loadFirstImageInPostSynchronously(isLCPImage) | safe }}
 
-        {%- set isLCPImage = true -%}
-        {{ content | loadFirstImageInPostSynchronously(isLCPImage) | safe }}
+        </div> <!-- /.e-content -->
 
-      </div> <!-- /.e-content -->
+        <footer class="l-flow l-flow--large post__footer">
+          <div class="l-cluster tags">
+            <p>Filed under:</p>
+            <ul role="list" class="l-cluster">
+            {% for tag in tags %}
+              {%- if (tag != "posts") and (tag != "link") and (tag != "note") and (tag != "entry") -%}
+              {% set tagUrl %}/tags/{{ tag }}/{% endset %}
+              <li><a rel="tag" href="{{ tagUrl | url }}" class="tags__tag">{{ tag }}</a></li>
+              {%- endif -%}
+            {% endfor %}
+            </ul>
+          </div>
 
-      <footer class="l-flow l-flow--large post__footer">
-        <div class="l-cluster tags">
-          <p>Filed under:</p>
-          <ul role="list" class="l-cluster">
-          {% for tag in tags %}
-            {%- if (tag != "posts") and (tag != "link") and (tag != "note") and (tag != "entry") -%}
-            {% set tagUrl %}/tags/{{ tag }}/{% endset %}
-            <li><a rel="tag" href="{{ tagUrl | url }}" class="tags__tag">{{ tag }}</a></li>
-            {%- endif -%}
-          {% endfor %}
-          </ul>
-        </div>
+          <nav class="traverse" aria-label="Pagination">
+            {%- set previousPost = collections.posts | getPreviousCollectionItem(page) %}
+            {%- if previousPost %}<a rel="prev" href="{{ previousPost.url | url }}"><span aria-hidden="true">← </span>Previous post</a></li>{% endif %}
+            {%- set nextPost = collections.posts | getNextCollectionItem(page) %}
+            {%- if nextPost %}<a rel="next" href="{{ nextPost.url | url }}">Next post<span aria-hidden="true"> →</span></a>{% endif %}
+          </nav>
+        </footer>
+      </article>
 
-        <nav class="traverse" aria-label="Pagination">
-          {%- set previousPost = collections.posts | getPreviousCollectionItem(page) %}
-          {%- if previousPost %}<a rel="prev" href="{{ previousPost.url | url }}"><span aria-hidden="true">← </span>Previous post</a></li>{% endif %}
-          {%- set nextPost = collections.posts | getNextCollectionItem(page) %}
-          {%- if nextPost %}<a rel="next" href="{{ nextPost.url | url }}">Next post<span aria-hidden="true"> →</span></a>{% endif %}
-        </nav>
-      </footer>
-    </article>
-
+    </div>
   </div>
-</div>
+</heading-anchors>


### PR DESCRIPTION
I was already loading Zach L’s [heading-anchors web component](https://github.com/zachleat/heading-anchors) JavaScript. Now I’ve got it working on blog posts by wrapping the relevant custom element around the blog post content.