### PR TITLE
Add automated test for the presence and correctness of key statically-generated outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,31 @@ Or build and run on a local development server:
 npm run start
 ```
 
+## Tests
+
+Currently, I use automated tests to check that certain key generated files are present and correct.
+
+Run all current Node test files:
+
+```
+npm test
+```
+
+Alternative direct command:
+
+```
+node --test _tests/*.test.mjs
+```
+
+Tests that need access to the built site should import `siteDir` from `_tests/helpers/site-paths.mjs`.
+You can override this auto-derived path in CI or local debugging by setting `SITE_DIR`.
+
 ## Features
 
 * Statically generated, fast loading pages using [Eleventy](https://www.11ty.dev/)
 * Hosted with [Netlify](https://www.netlify.com/)
 * Focused on accessibility, performance and web good practices ([100/100 scores for all on Lighthouse](https://pagespeed.web.dev/analysis/https-fuzzylogic-me/dz2w9dl44v?form_factor=mobile))
+* Includes automated test suite for ensuring that key statically-generated output files remain present and correct through updates
 * Supports `draft` posts that are skipped in production builds [using 11ty’s Preprocessor API](https://www.11ty.dev/docs/config-preprocessors/#example-drafts)
 * Supports excerpts
 * Content editing via [Decap CMS](https://decapcms.org/)
@@ -53,7 +73,7 @@ npm run start
 * 404 page shown when necessary, thanks to [Netlify’s custom 404 page handling](https://docs.netlify.com/routing/redirects/redirect-options/#custom-404-page-handling)
 * Code block syntax highlighting performed at build time rather than on the client, via 11ty’s [Syntax Hightlighting plugin](https://www.11ty.dev/docs/plugins/syntaxhighlight/) which in turn uses [prism.js](https://prismjs.com/)
 * Supports deep-linking to headings via Zach Leatherman’s [heading-anchors](https://github.com/zachleat/heading-anchors) web component
-* RSS feed using 11ty’s [RSS plugin](https://www.11ty.dev/docs/plugins/rss/). 
+* RSS feed using 11ty’s [RSS plugin](https://www.11ty.dev/docs/plugins/rss/).
 * Tags page which lists all tags as links; plus “Posts tagged with x” pages
 * Uses [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) for both client-side JS and on the server
 * Pure modern CSS with no pre- or post- processing dependencies. Layers, native nesting, etc.
@@ -75,7 +95,7 @@ The `content` directory is for files I want processed by 11ty – “templates�
 
 The `public` directory is for files I want 11ty to skip and pass straight through.
 
-11ty puts compiled content into the `_site` directory and it’s served from there to the public. 
+11ty puts compiled content into the `_site` directory and it’s served from there to the public.
 
 #### Excerpts
 

--- a/_tests/assets.test.mjs
+++ b/_tests/assets.test.mjs
@@ -1,0 +1,34 @@
+// Idea from Kitty Giraudel – thanks!:
+// https://kittygiraudel.com/2026/03/12/adding-tests-to-an-eleventy-site/
+
+import assert from 'node:assert/strict'
+import { readdir, stat } from 'node:fs/promises'
+import path from 'node:path'
+import test from 'node:test'
+import { siteDir } from './helpers/site-paths.mjs'
+
+async function expectFile(relativePath) {
+	const full = path.join(siteDir, relativePath)
+	const s = await stat(full)
+	assert.ok(s.isFile(), `${relativePath} should exist as a file`)
+}
+
+async function expectDirectoryWithFiles(relativePath) {
+	const full = path.join(siteDir, relativePath)
+	const s = await stat(full)
+	assert.ok(s.isDirectory(), `${relativePath} should exist as a directory`)
+	const files = await readdir(full)
+	assert.ok(files.length > 0, `${relativePath} should not be empty`)
+}
+
+test('Core assets exist in built site', async () => {
+	await Promise.all([
+		expectFile('robots.txt'),
+    expectFile('favicon.ico'),
+		expectFile('404.html'),
+    expectFile('sitemap.xml'),
+    expectFile('feed/feed.xml'),
+		expectDirectoryWithFiles('img'),
+		expectDirectoryWithFiles('pagefind'),
+	])
+})

--- a/_tests/helpers/site-paths.mjs
+++ b/_tests/helpers/site-paths.mjs
@@ -1,0 +1,9 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const helpersDir = path.dirname(fileURLToPath(import.meta.url))
+const testsDir = path.resolve(helpersDir, '..')
+
+export const siteDir = process.env.SITE_DIR
+	? path.resolve(process.env.SITE_DIR)
+	: path.resolve(testsDir, '..', '_site')

--- a/_tests/site-paths.test.mjs
+++ b/_tests/site-paths.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import test from 'node:test'
+import { siteDir } from './helpers/site-paths.mjs'
+
+test('siteDir helper returns an absolute path', () => {
+	assert.equal(typeof siteDir, 'string')
+	assert.ok(siteDir.length > 0)
+	assert.ok(path.isAbsolute(siteDir), 'siteDir should be absolute')
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "prebuild": "rm -rf _site/",
-    "build": "npx @11ty/eleventy && npx pagefind --site _site",
+    "build": "npx @11ty/eleventy && npx pagefind --site _site && npm test",
+    "test": "node --test _tests/*.test.mjs",
     "start": "npx @11ty/eleventy --serve --quiet --incremental --ignore-initial",
     "debugstart": "DEBUG=Eleventy* npx @11ty/eleventy --serve --quiet",
     "debug": "DEBUG=Eleventy* npx @11ty/eleventy",


### PR DESCRIPTION
Big thanks to [Kitty’s post](https://kittygiraudel.com/2026/03/12/adding-tests-to-an-eleventy-site/) for the inspiration.

- Adds (non-11ty-processed) `_tests` directory
- Adds `helpers` subdirectory including a helper module that provides an absolute filepath to the `_site` output directory (and a test for that module)
- Adds first main test file, which tests for the presence of certain key files and directories in the 11ty generated output

Also:
Adds 'test' npm script, and makes ”tests ran and passing“ part of the npm `build` script, which is the script Netlify runs.