### PR TITLE
Improve load-in of pagefind search form

### DIFF
--- a/content/search/index.md
+++ b/content/search/index.md
@@ -12,11 +12,10 @@ eleventyNavigation:
 
 Type your search term into the form below.
 
-<div>
+<search class="search">
   <!-- Fall back to DuckDuckGo site search (use any search engine here) -->
   <pagefind-search pagefind-autofocus>
-    <form action="https://duckduckgo.com/" method="get" style="min-height: 3.2em;">
-    <!-- min-height to reduce CLS -->
+    <form class="searchform-basic" action="https://duckduckgo.com/" method="get">
       <label style="display: inline;">
         Search for:
         <input style="max-width: 16rem;" type="search" name="q" autocomplete="off" autofocus>
@@ -26,4 +25,4 @@ Type your search term into the form below.
       <button type="submit">Search</button>
     </form>
   </pagefind-search>
-</div>
+</search>

--- a/css/index.css
+++ b/css/index.css
@@ -689,6 +689,38 @@
 
 
   /* ==========================================================================
+    # SEARCH
+    ========================================================================== */
+
+  @layer base {
+    @keyframes fadeIn {
+      /* for a 2-step animation in keyframes,
+      defining start or end alone is sufficient */
+      from {
+        opacity: 0;
+      }
+    }
+  }
+
+  @layer components {
+    .search, .searchform-basic {
+      /* min-height to reduce CLS during progressive enhancement */
+      min-height: 3.2em;
+    }
+
+    .searchform-basic {
+      /* fade in the basic fallback form rather than showing it immediatately.
+      This allows time for the enhanced pagefind form to load in and
+      lessens the likelihood of a jarring transition between the two.
+      Note: if the pagefind form fails to load, the basic form will be
+      presented. */
+      animation: fadeIn 3s ease-in-out;
+    }
+  }
+
+
+
+  /* ==========================================================================
     # ARTICLES
     ========================================================================== */
 


### PR DESCRIPTION
Previously we showed the basic fallback form immediately, then the pagefind webcomponent JS would replace that basic form with a pagefind form. This is good, but it was a temporarily jarring experience. 

This update avoids a jarring transition between fallback search form and enhanced pagefind search form, by animating in the basic form from invisible to visible over a short period of time. If the upgrade to pagefind form worked, the replacement will have happened before the animation has time to finish, and the basic for will never be seen.